### PR TITLE
Implementation of the upload local command

### DIFF
--- a/src/Velopack.Deployment/LocalRepository.cs
+++ b/src/Velopack.Deployment/LocalRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Velopack.Packaging;
 using Velopack.Sources;
 
 namespace Velopack.Deployment;
@@ -8,10 +9,65 @@ public class LocalDownloadOptions : RepositoryOptions
     public DirectoryInfo Path { get; set; }
 }
 
-public class LocalRepository(ILogger logger) : SourceRepository<LocalDownloadOptions, SimpleFileSource>(logger)
+public class LocalUploadOptions : LocalDownloadOptions
+{
+    public DirectoryInfo SecondPath { get; set; }
+    public bool SkipUploadPortable { get; set; }
+    public bool SkipUploadInstaller { get; set; }
+}
+
+public class LocalRepository(ILogger logger) : SourceRepository<LocalDownloadOptions, SimpleFileSource>(logger), IRepositoryCanUpload<LocalUploadOptions>
 {
     public override SimpleFileSource CreateSource(LocalDownloadOptions options)
     {
         return new SimpleFileSource(options.Path);
+    }
+
+    public async Task UploadMissingAssetsAsync(LocalUploadOptions options)
+    {
+        var build = BuildAssets.Read(options.ReleaseDir.FullName, options.Channel);
+        Log.Info($"Preparing to upload {build.Files.Count} local assets to local path {options.Path}");
+
+        var remoteReleases = await GetReleasesAsync(options);
+        Log.Info($"There are {remoteReleases.Assets.Length} assets in remote RELEASES file.");
+
+        var localEntries = build.GetReleaseEntries();
+        var releaseEntries = ReleaseEntryHelper.MergeAssets(localEntries, remoteReleases.Assets).ToArray();
+        Log.Info($"{releaseEntries.Length} merged local/remote releases.");
+
+        foreach (var asset in build.Files) {
+            if (Path.GetExtension(asset).Contains(".zip")) {
+                if (options.SkipUploadPortable == true) { continue; }
+                if (options.SecondPath != null) {
+                    if (!Directory.Exists(options.SecondPath.FullName)) { Directory.CreateDirectory(options.SecondPath.FullName); }
+                    File.Copy(asset, Path.Combine(options.SecondPath.FullName, Path.GetFileName(asset)));
+                    continue;
+                }
+            } else if (Path.GetExtension(asset).Contains(".exe")) {
+                if (options.SkipUploadInstaller == true) { continue; }
+                if (options.SecondPath != null) {
+                    if (!Directory.Exists(options.SecondPath.FullName)) { Directory.CreateDirectory(options.SecondPath.FullName); }
+                    File.Copy(asset, Path.Combine(options.SecondPath.FullName, Path.GetFileName(asset)));
+                    continue;
+                }
+            }
+            File.Copy(asset, Path.Combine(options.Path.FullName, Path.GetFileName(asset)));
+        }
+
+        var releasesName = Utility.GetVeloReleaseIndexName(options.Channel);
+        var releasesFile = Path.Combine(options.ReleaseDir.FullName, releasesName);
+        File.WriteAllText(releasesFile, ReleaseEntryHelper.GetAssetFeedJson(new VelopackAssetFeed { Assets = releaseEntries }));
+        File.Copy(releasesFile, Path.Combine(options.Path.FullName, releasesName), true);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+        var legacyReleasesName = Utility.GetReleasesFileName(options.Channel);
+        var legacyReleasesFile = Path.Combine(options.ReleaseDir.FullName, legacyReleasesName);
+        ReleaseEntry.WriteReleaseFile(releaseEntries.Select(ReleaseEntry.FromVelopackAsset), legacyReleasesFile);
+        File.Copy(legacyReleasesFile, Path.Combine(options.Path.FullName, legacyReleasesName), true);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0612 // Type or member is obsolete
+
+        Log.Info("Done.");
     }
 }

--- a/src/Velopack.Vpk/Commands/LocalBaseCommand.cs
+++ b/src/Velopack.Vpk/Commands/LocalBaseCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace Velopack.Vpk.Commands;
+public abstract class LocalBaseCommand : OutputCommand
+{
+    public DirectoryInfo Path { get; private set; }
+
+    protected CliOption<DirectoryInfo> PathOption { get; private set; }
+
+    public LocalBaseCommand(string name, string description)
+        : base(name, description)
+    {
+        PathOption = AddOption<DirectoryInfo>((v) => Path = v, "-p", "--path")
+            .MustExist()
+            .SetRequired();
+    }
+}

--- a/src/Velopack.Vpk/Commands/LocalDownloadCommand.cs
+++ b/src/Velopack.Vpk/Commands/LocalDownloadCommand.cs
@@ -1,15 +1,10 @@
 ﻿namespace Velopack.Vpk.Commands;
 
-public class LocalDownloadCommand : OutputCommand
+public class LocalDownloadCommand : LocalBaseCommand
 {
-    public DirectoryInfo Path { get; private set; }
-
     public LocalDownloadCommand()
         : base("local", "Download latest release from a local path source.")
     {
-        AddOption<DirectoryInfo>((p) => Path = p, "--path")
-            .SetDescription("Path to download releases from.")
-            .MustExist()
-            .SetRequired();
+        PathOption.SetDescription("Path to download releases from.");
     }
 }

--- a/src/Velopack.Vpk/Commands/LocalUploadCommand.cs
+++ b/src/Velopack.Vpk/Commands/LocalUploadCommand.cs
@@ -1,0 +1,25 @@
+﻿namespace Velopack.Vpk.Commands;
+
+public class LocalUploadCommand : LocalBaseCommand
+{
+    public DirectoryInfo SecondPath { get; private set; }
+
+    public bool SkipUploadPortable { get; private set; }
+
+    public bool SkipUploadInstaller { get; private set; }
+
+    public LocalUploadCommand()
+        : base("local", "Upload releases to a local path source.")
+    {
+        PathOption.SetDescription("Path to upload releases to.");
+
+        AddOption<DirectoryInfo>((v) => SecondPath = v, "-sp", "--secondPath")
+            .SetDescription("Path to upload the portable version of the application and the installer to. They will not be uploaded to the main path if this option is present. If the folder does not exist, it will be created.");
+
+        AddOption<bool>((v) => SkipUploadPortable = v, "--skipPortable")
+            .SetDescription("Skip uploading the portable version of the application.");
+
+        AddOption<bool>((v) => SkipUploadInstaller = v, "--skipInstaller")
+            .SetDescription("Skip uploading the installer of the application.");
+    }
+}

--- a/src/Velopack.Vpk/OptionMapper.cs
+++ b/src/Velopack.Vpk/OptionMapper.cs
@@ -21,6 +21,7 @@ public static partial class OptionMapper
     public static partial GitHubDownloadOptions ToOptions(this GitHubDownloadCommand cmd);
     public static partial GitHubUploadOptions ToOptions(this GitHubUploadCommand cmd);
     public static partial HttpDownloadOptions ToOptions(this HttpDownloadCommand cmd);
+    public static partial LocalUploadOptions ToOptions(this LocalUploadCommand cmd);
     public static partial LocalDownloadOptions ToOptions(this LocalDownloadCommand cmd);
     public static partial S3DownloadOptions ToOptions(this S3DownloadCommand cmd);
     public static partial S3UploadOptions ToOptions(this S3UploadCommand cmd);

--- a/src/Velopack.Vpk/Program.cs
+++ b/src/Velopack.Vpk/Program.cs
@@ -89,6 +89,7 @@ public class Program
         var uploadCommand = new CliCommand("upload", "Upload local package(s) to a remote update source.");
         uploadCommand.AddRepositoryUpload<GitHubUploadCommand, GitHubRepository, GitHubUploadOptions>(provider);
         uploadCommand.AddRepositoryUpload<S3UploadCommand, S3Repository, S3UploadOptions>(provider);
+        uploadCommand.AddRepositoryUpload<LocalUploadCommand, LocalRepository, LocalUploadOptions>(provider);
         rootCommand.Add(uploadCommand);
 
         var deltaCommand = new CliCommand("delta", "Utilities for creating or applying delta packages.");


### PR DESCRIPTION
First draft.

This new command has 4 options:
1. The path to which we would like to upload. (Required)
2. Second path. If this option is populated, the nupks will be uploaded to the original path but the files portable.zip and setup.exe will be uploaded to this second path instead. If the folder does not exist, it will be created.
3. SkipUploadPortable. If this option is present, the file portable.zip will not be uploaded regardless if the second path is populated or not.
4. SkipUploadInstaller. If this option is present, the file setup.exe will not be uploaded regardless if the second path is populated or not.

All feedback is welcomed.