### PR TITLE
fix: ensure new files are applied from deltas

### DIFF
--- a/src/Velopack/Compression/DeltaPackage.cs
+++ b/src/Velopack/Compression/DeltaPackage.cs
@@ -73,7 +73,7 @@ namespace Velopack.Compression
             deltaPathRelativePaths
                 .Where(x => x.StartsWith("lib", StringComparison.InvariantCultureIgnoreCase) 
                             && !x.EndsWith(".shasum", StringComparison.InvariantCultureIgnoreCase)
-                            && !pathsVisited.Contains(x))
+                            && !pathsVisited.Contains(DIFF_SUFFIX.Replace(x, ""), StringComparer.InvariantCultureIgnoreCase))
                 .ForEach(x => {
                     Log.Trace($"{x} was in new package but not in old one, adding");
                     File.Copy(Path.Combine(deltaPath, x), Path.Combine(workingPath, x));

--- a/src/Velopack/Compression/DeltaPackage.cs
+++ b/src/Velopack/Compression/DeltaPackage.cs
@@ -38,14 +38,14 @@ namespace Velopack.Compression
             var deltaPathRelativePaths = new DirectoryInfo(deltaPath).GetAllFilesRecursively()
                 .Select(x => x.FullName.Replace(deltaPath + Path.DirectorySeparatorChar, ""))
                 .ToArray();
-
+            
             // Apply all of the .diff files
             var files = deltaPathRelativePaths
                 .Where(x => x.StartsWith("lib", StringComparison.InvariantCultureIgnoreCase))
                 .Where(x => !x.EndsWith(".shasum", StringComparison.InvariantCultureIgnoreCase))
                 .Where(x => DIFF_SUFFIX.IsMatch(x))
                 .ToArray();
-
+            
             for (var index = 0; index < files.Length; index++) {
                 var file = files[index];
                 pathsVisited.Add(DIFF_SUFFIX.Replace(file, "").ToLowerInvariant());
@@ -54,8 +54,8 @@ namespace Velopack.Compression
                 progress(Utility.CalculateProgress((int) perc, 10, 90));
             }
 
-            progress(90);
-
+            progress(80);
+            
             // Delete all of the files that were in the old package but
             // not in the new one.
             new DirectoryInfo(workingPath).GetAllFilesRecursively()
@@ -64,6 +64,19 @@ namespace Velopack.Compression
                 .ForEach(x => {
                     Log.Trace($"{x} was in old package but not in new one, deleting");
                     File.Delete(Path.Combine(workingPath, x));
+                });
+            
+            progress(85);
+            
+            // Add all of the files that are in the new package but
+            // not in the old one.
+            deltaPathRelativePaths
+                .Where(x => x.StartsWith("lib", StringComparison.InvariantCultureIgnoreCase) 
+                            && !x.EndsWith(".shasum", StringComparison.InvariantCultureIgnoreCase)
+                            && !pathsVisited.Contains(x))
+                .ForEach(x => {
+                    Log.Trace($"{x} was in new package but not in old one, adding");
+                    File.Copy(Path.Combine(deltaPath, x), Path.Combine(workingPath, x));
                 });
 
             progress(95);

--- a/test/Velopack.Packaging.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Packaging.Tests/WindowsPackTests.cs
@@ -295,7 +295,7 @@ public class WindowsPackTests
         using var logger = _output.BuildLoggerFor<WindowsPackTests>();
         string id = "SquirrelDeltaTest";
         PackTestApp(id, "1.0.0", "version 1 test", releaseDir, logger);
-        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger);
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger, true);
 
         // did a zsdiff get created for our v2 update?
         var deltaPath = Path.Combine(releaseDir, $"{id}-2.0.0-delta.nupkg");
@@ -652,7 +652,7 @@ public class WindowsPackTests
         return RunImpl(psi, logger, exitCode);
     }
 
-    private void PackTestApp(string id, string version, string testString, string releaseDir, ILogger logger)
+    private void PackTestApp(string id, string version, string testString, string releaseDir, ILogger logger, bool addNewFile = false)
     {
         var projDir = PathHelper.GetTestRootPath("TestApp");
         var testStringFile = Path.Combine(projDir, "Const.cs");
@@ -673,6 +673,16 @@ public class WindowsPackTests
 
             if (p.ExitCode != 0)
                 throw new Exception($"dotnet publish failed with exit code {p.ExitCode}");
+
+            var newFilePath = Path.Combine(projDir, "publish", "NewFile.txt");
+            if (addNewFile) {
+                File.WriteAllText(newFilePath, "New File Test");
+            } else {
+                // This is needed as the presence of this file in v1.0.0 can give false positives in the delta test
+                if (File.Exists(newFilePath)) {
+                    File.Delete(newFilePath);
+                }
+            }
 
             //RunNoCoverage("dotnet", args, projDir, logger);
 


### PR DESCRIPTION
This fix resolved my issue where new DLLs present in deltas were not being applied to the application when updating.

I'm still very new to Velopack's code, so it would be worth a little scrutiny before merging in.