### PR TITLE
Adding MSBuild project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,18 @@ root = true
 # All files 
 [*] 
 indent_style = space 
+
+# MSBuild files
+[*.{csproj,targets,props}]
+indent_size = 2
+
+# Xml files
+[*.xml]
+indent_size = 2
+
 # Code files 
 [*.{cs,csx,vb,vbx}] 
-indent_size = 4 
+indent_size = 4
 insert_final_newline = true 
 charset = utf-8-bom 
 ############################### 
@@ -37,9 +46,9 @@ dotnet_style_readonly_field = true:suggestion
 dotnet_style_object_initializer = true:suggestion 
 dotnet_style_collection_initializer = true:suggestion 
 dotnet_style_explicit_tuple_names = true:suggestion 
-dotnet_style_null_propagation = true:suggestion 
-dotnet_style_coalesce_expression = true:suggestion 
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
 dotnet_prefer_inferred_tuple_names = true:suggestion 
 dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
 dotnet_style_prefer_auto_properties = true:silent 
@@ -51,13 +60,16 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 # Style Definitions 
 dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
 # Use PascalCase for constant fields   
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
 dotnet_naming_symbols.constant_fields.required_modifiers          = const 
 dotnet_diagnostic.CA2007.severity=warning
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf
 ############################### 
 # C# Coding Conventions       # 
 ############################### 
@@ -67,12 +79,12 @@ csharp_style_var_for_built_in_types = true:silent
 csharp_style_var_when_type_is_apparent = true:silent 
 csharp_style_var_elsewhere = true:silent 
 # Expression-bodied members 
-csharp_style_expression_bodied_methods = false:silent 
-csharp_style_expression_bodied_constructors = false:silent 
-csharp_style_expression_bodied_operators = false:silent 
-csharp_style_expression_bodied_properties = true:silent 
-csharp_style_expression_bodied_indexers = true:silent 
-csharp_style_expression_bodied_accessors = true:silent 
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
 # Pattern matching preferences 
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
@@ -82,7 +94,7 @@ csharp_style_conditional_delegate_call = true:suggestion
 # Modifier preferences 
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
 # Expression-level preferences 
-csharp_prefer_braces = true:silent 
+csharp_prefer_braces = true:silent
 csharp_style_deconstructed_variable_declaration = true:suggestion 
 csharp_prefer_simple_default_expression = true:suggestion 
 csharp_style_pattern_local_over_anonymous_function = true:suggestion 
@@ -101,7 +113,7 @@ csharp_new_line_between_query_expression_clauses =false
 # Indentation preferences 
 csharp_indent_case_contents = true 
 csharp_indent_switch_labels = false 
-csharp_indent_labels = one_less_than_current 
+csharp_indent_labels = one_less_than_current
 # Space preferences 
 csharp_space_after_cast = true 
 csharp_space_after_keywords_in_control_flow_statements = true 

--- a/.gitignore
+++ b/.gitignore
@@ -504,5 +504,4 @@ tests/Test.xml
 *.opendb
 .vs/
 
-
 launchsettings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cSpell.words": [
+        "Avalonia",
+        "Skippable",
+        "Velo",
+        "Velopack"
+    ]
+}

--- a/Velopack.sln
+++ b/Velopack.sln
@@ -51,6 +51,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Divergic.Logging.Xunit", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Velopack.Packaging.HostModel", "src\Velopack.Packaging.HostModel\Velopack.Packaging.HostModel.csproj", "{E9A2620C-C638-446C-BA30-F62C05709365}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Velopack.Build", "src\Velopack.Build\Velopack.Build.csproj", "{97C9B2CF-877F-4C98-A513-058784A23697}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{E9A2620C-C638-446C-BA30-F62C05709365}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9A2620C-C638-446C-BA30-F62C05709365}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9A2620C-C638-446C-BA30-F62C05709365}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97C9B2CF-877F-4C98-A513-058784A23697}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97C9B2CF-877F-4C98-A513-058784A23697}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97C9B2CF-877F-4C98-A513-058784A23697}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97C9B2CF-877F-4C98-A513-058784A23697}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/AvaloniaCrossPlat/AvaloniaCrossPlat.csproj
+++ b/samples/AvaloniaCrossPlat/AvaloniaCrossPlat.csproj
@@ -7,6 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <NoWarn>$(NoWarn);IDE0161</NoWarn>
+    <!--<UseLocalVelopack>true</UseLocalVelopack>-->
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,8 @@
     </Otherwise>
   </Choose>
 
+
+
   <!-- For demonstrating updates, so the installed application can find the Release directory -->
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
@@ -40,4 +43,5 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <Import Project="..\..\src\Velopack.Build\Velopack.Build.targets" Condition=" $(UseLocalVelopack) != '' " />
 </Project>

--- a/samples/AvaloniaCrossPlat/MainWindow.axaml.cs
+++ b/samples/AvaloniaCrossPlat/MainWindow.axaml.cs
@@ -17,6 +17,8 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         _um = new UpdateManager(Program.UpdateUrl, logger: Program.Log);
+        //_um = new UpdateManager(new VelopackFlowUpdateSource(), logger: Program.Log);
+
         TextLog.Text = Program.Log.ToString();
         Program.Log.LogUpdated += LogUpdated;
         UpdateStatus();

--- a/samples/VeloWpfSample/MainWindow.xaml.cs
+++ b/samples/VeloWpfSample/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using Microsoft.Extensions.Logging;
 using Velopack;
+using Velopack.Sources;
 
 namespace VeloWpfSample
 {
@@ -14,6 +15,7 @@ namespace VeloWpfSample
         {
             InitializeComponent();
             _um = new UpdateManager(Program.UpdateUrl, logger: Program.Log);
+            //_um = new UpdateManager(new VelopackFlowUpdateSource(), logger: Program.Log);
             TextLog.Text = Program.Log.ToString();
             Program.Log.LogUpdated += LogUpdated;
             UpdateStatus();

--- a/samples/VeloWpfSample/Program.cs
+++ b/samples/VeloWpfSample/Program.cs
@@ -4,6 +4,7 @@ using Velopack;
 
 namespace VeloWpfSample
 {
+
     public class Program
     {
         public static bool WasFirstRun { get; private set; }

--- a/samples/VeloWpfSample/VeloWpfSample.csproj
+++ b/samples/VeloWpfSample/VeloWpfSample.csproj
@@ -8,6 +8,7 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);IDE0161</NoWarn>
+    <!--<UseLocalVelopack>true</UseLocalVelopack>-->
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,11 +16,22 @@
     <StartupObject>VeloWpfSample.Program</StartupObject>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Velopack" Version="0.*" />
-  </ItemGroup>
+  <!-- For test build scripts which target the local Velopack project instead of the NuGet package -->
+  <Choose>
+    <When Condition=" $(UseLocalVelopack) != '' ">
+      <ItemGroup>
+        <ProjectReference Include="..\..\src\Velopack\Velopack.csproj" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Velopack" Version="0.*" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- Used for demonstrating updates, so the installed application can find the Release directory, remove in your app -->
+  <!-- Used for demonstrating updates, so the installed application can find the Release directory -->
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>WpfSampleReleaseDir</_Parameter1>
@@ -27,4 +39,5 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <Import Project="..\..\src\Velopack.Build\Velopack.Build.targets" Condition=" $(UseLocalVelopack) != '' " />
 </Project>

--- a/src/Velopack.Build/MSBuildAsyncTask.cs
+++ b/src/Velopack.Build/MSBuildAsyncTask.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using MSBuildTask = Microsoft.Build.Utilities.Task;
+
+namespace Velopack.Build;
+
+public abstract class MSBuildAsyncTask : MSBuildTask
+{
+    protected MSBuildLogger Logger { get; }
+
+    protected MSBuildAsyncTask()
+    {
+        Logger = new MSBuildLogger(Log);
+    }
+
+    public sealed override bool Execute()
+    {
+        try {
+            return Task.Run(ExecuteAsync).Result;
+        } catch (AggregateException ex) {
+            ex.Flatten().Handle((x) => {
+                Log.LogError(x.Message);
+                return true;
+            });
+            return false;
+        }
+    }
+
+    protected abstract Task<bool> ExecuteAsync();
+}

--- a/src/Velopack.Build/MSBuildLogger.cs
+++ b/src/Velopack.Build/MSBuildLogger.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.Logging;
+using Velopack.Packaging.Abstractions;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using Task = System.Threading.Tasks.Task;
+
+namespace Velopack.Build;
+
+public class MSBuildLogger(TaskLoggingHelper loggingHelper) : ILogger, IFancyConsole, IFancyConsoleProgress
+{
+    private TaskLoggingHelper LoggingHelper { get; } = loggingHelper;
+
+    IDisposable ILogger.BeginScope<TState>(TState state)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task ExecuteProgressAsync(Func<IFancyConsoleProgress, Task> action)
+    {
+        await action(this).ConfigureAwait(false);
+    }
+
+    public async Task RunTask(string name, Func<Action<int>, Task> fn)
+    {
+        try {
+            await fn(x => { }).ConfigureAwait(false);
+        } catch (Exception ex) {
+            this.LogError(ex, "Error running task {0}", name);
+        }
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return logLevel switch {
+            LogLevel.Trace => LoggingHelper.LogsMessagesOfImportance(MessageImportance.Low),
+            LogLevel.Debug => LoggingHelper.LogsMessagesOfImportance(MessageImportance.Normal),
+            LogLevel.Information => LoggingHelper.LogsMessagesOfImportance(MessageImportance.High),
+            _ => true,
+        };
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId _, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        string message = formatter(state, exception);
+        if (exception != null) {
+            message += " " + exception.Message;
+        }
+        switch (logLevel) {
+        case LogLevel.Trace:
+            LoggingHelper.LogMessage(MessageImportance.Low, message);
+            break;
+        case LogLevel.Debug:
+            LoggingHelper.LogMessage(MessageImportance.Normal, message);
+            break;
+        case LogLevel.Information:
+            LoggingHelper.LogMessage(MessageImportance.High, message);
+            break;
+        case LogLevel.Warning:
+            LoggingHelper.LogWarning(message);
+            break;
+        case LogLevel.Error:
+        case LogLevel.Critical:
+            LoggingHelper.LogError(message);
+            break;
+        }
+    }
+
+    public void WriteTable(string tableName, IEnumerable<IEnumerable<string>> rows, bool hasHeaderRow = true)
+    {
+        //Do we need this output for MSBuild?
+    }
+
+    public System.Threading.Tasks.Task<bool> PromptYesNo(string prompt, bool? defaultValue = null, TimeSpan? timeout = null)
+    {
+        //TODO: This API is problematic as it assumes interactive.
+        return Task.FromResult(true);
+    }
+
+    public void WriteLine(string text = "")
+    {
+        Log(LogLevel.Information, 0, null, null, (object? state, Exception? exception) => text);
+    }
+}

--- a/src/Velopack.Build/PackTask.cs
+++ b/src/Velopack.Build/PackTask.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Velopack.Packaging;
+using Velopack.Packaging.Windows.Commands;
+
+namespace Velopack.Build;
+
+public class PackTask : MSBuildAsyncTask
+{
+    public string? TargetRuntime { get; set; }
+
+    [Required]
+    public string PackVersion { get; set; } = "";
+
+    [Required]
+    public string Runtimes { get; set; } = "";
+
+    [Required]
+    public string PackId { get; set; } = "";
+
+    [Required]
+    public string PackDirectory { get; set; } = null!;
+
+    [Required]
+    public string ReleaseDirectory { get; set; } = null!;
+
+    protected override async Task<bool> ExecuteAsync()
+    {
+        //System.Diagnostics.Debugger.Launch();
+        HelperFile.AddSearchPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+        if (VelopackRuntimeInfo.IsWindows) {
+
+            var targetRuntime = RID.Parse(TargetRuntime ?? VelopackRuntimeInfo.SystemOs.GetOsShortName());
+            if (targetRuntime.BaseRID == RuntimeOs.Unknown) {
+                //TODO: handle this error case
+            }
+
+            DirectoryInfo releaseDir = new(ReleaseDirectory);
+            releaseDir.Create();
+
+            var runner = new WindowsPackCommandRunner(Logger, Logger);
+            await runner.Run(new WindowsPackOptions() {
+                PackId = PackId,
+                ReleaseDir = releaseDir,
+                PackDirectory = PackDirectory,
+                Runtimes = Runtimes,
+                TargetRuntime = targetRuntime,
+                PackVersion = PackVersion,
+            }).ConfigureAwait(false);
+
+            Log.LogMessage(MessageImportance.High, $"{PackId} ({PackVersion}) created in {ReleaseDirectory}");
+        } else if (VelopackRuntimeInfo.IsOSX) {
+            //TODO: Implement
+
+        } else if (VelopackRuntimeInfo.IsLinux) {
+            //TODO: Implement
+
+        } else {
+            //TODO: Do we really want to fail to pack (effectively failing the user's publish, or should we just warn?
+            throw new NotSupportedException("Unsupported OS platform: " + VelopackRuntimeInfo.SystemOs.GetOsLongName());
+        }
+        return true;
+    }
+}

--- a/src/Velopack.Build/PublishTask.cs
+++ b/src/Velopack.Build/PublishTask.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
+using Velopack.Packaging;
+using Velopack.Packaging.Flow;
+
+namespace Velopack.Build;
+
+public class PublishTask : MSBuildAsyncTask
+{
+    private static HttpClient HttpClient { get; } = new();
+
+    [Required]
+    public string ReleaseDirectory { get; set; } = "";
+
+    public string ServiceUrl { get; set; } = VelopackServiceOptions.DefaultBaseUrl;
+
+    public string? Channel { get; set; }
+
+    public string? Version { get; set; } 
+
+    protected override async Task<bool> ExecuteAsync()
+    {
+        //System.Diagnostics.Debugger.Launch();
+        VelopackFlowServiceClient client = new(HttpClient, Logger);
+        if (!await client.LoginAsync(new() {
+            AllowDeviceCodeFlow = false,
+            AllowInteractiveLogin = false,
+            VelopackBaseUrl = ServiceUrl
+        }).ConfigureAwait(false)) {
+            Logger.LogWarning("Not logged into Velopack service, skipping publish. Please run vpk login.");
+            return true;
+        }
+
+        Channel ??= ReleaseEntryHelper.GetDefaultChannel(VelopackRuntimeInfo.SystemOs);
+        ReleaseEntryHelper helper = new(ReleaseDirectory, Channel, Logger);
+        var latestAssets = helper.GetLatestAssets().ToList();
+
+        List<string> installers = [];
+
+        List<string> files = latestAssets.Select(x => x.FileName).ToList();
+        string? packageId = null;
+        SemanticVersion? version = null;
+        if (latestAssets.Count > 0) {
+            packageId = latestAssets[0].PackageId;
+            version = latestAssets[0].Version;
+
+            if (VelopackRuntimeInfo.IsWindows || VelopackRuntimeInfo.IsOSX) {
+                var setupName = ReleaseEntryHelper.GetSuggestedSetupName(packageId, Channel);
+                if (File.Exists(Path.Combine(ReleaseDirectory, setupName))) {
+                    installers.Add(setupName);
+                }
+            }
+
+            var portableName = ReleaseEntryHelper.GetSuggestedPortableName(packageId, Channel);
+            if (File.Exists(Path.Combine(ReleaseDirectory, portableName))) {
+                installers.Add(portableName);
+            }
+        }
+
+        Logger.LogInformation("Preparing to upload {AssetCount} assets to Velopack ({ServiceUrl})", latestAssets.Count + installers.Count, ServiceUrl);
+
+        foreach (var assetFileName in files) {
+
+            var latestPath = Path.Combine(ReleaseDirectory, assetFileName);
+
+            using var fileStream = File.OpenRead(latestPath);
+            var options = new UploadOptions(fileStream, assetFileName, Channel) {
+                VelopackBaseUrl = ServiceUrl
+            };
+
+            await client.UploadReleaseAssetAsync(options).ConfigureAwait(false);
+
+            Logger.LogInformation("Uploaded {FileName} to Velopack", assetFileName);
+        }
+
+        foreach(var installerFile in installers) {
+            var latestPath = Path.Combine(ReleaseDirectory, installerFile);
+
+            using var fileStream = File.OpenRead(latestPath);
+            var options = new UploadInstallerOptions(packageId!, version!, fileStream, installerFile, Channel) {
+                VelopackBaseUrl = ServiceUrl
+            };
+
+            await client.UploadInstallerAssetAsync(options).ConfigureAwait(false);
+
+            Logger.LogInformation("Uploaded {FileName} installer to Velopack", installerFile);
+        }
+        return true;
+
+    }
+}

--- a/src/Velopack.Build/Velopack.Build.csproj
+++ b/src/Velopack.Build/Velopack.Build.csproj
@@ -1,0 +1,77 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
+    <!-- 
+    https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props?WT.mc_id=DT-MVP-5003472#copylocallockfileassemblies
+    -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Velopack.Packaging.Unix\Velopack.Packaging.Unix.csproj" />
+    <ProjectReference Include="..\Velopack.Packaging.Windows\Velopack.Packaging.Windows.csproj" />
+    <ProjectReference Include="..\Velopack\Velopack.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+  </PropertyGroup>
+
+  <PropertyGroup Label="MacOS" Condition="$([System.OperatingSystem]::IsMacOS())">
+    <VelopackRustOutputDirectory>..\Rust\target</VelopackRustOutputDirectory>
+    <VelopackUpdateExe>UpdateMac</VelopackUpdateExe>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([System.OperatingSystem]::IsMacOS())">
+    <None Include="..\Rust\target\$(VelopackUpdateExe)" Link="$(VelopackUpdateExe)" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <PropertyGroup Label="Linux" Condition="$([System.OperatingSystem]::IsLinux())">
+    <VelopackRustOutputDirectory>..\Rust\target</VelopackRustOutputDirectory>
+    <VelopackUpdateExe>UpdateNix</VelopackUpdateExe>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([System.OperatingSystem]::IsMacOS())">
+    <None Include="..\Rust\target\$(VelopackUpdateExe)" Link="$(VelopackUpdateExe)" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <PropertyGroup Label="Windows" Condition="$([System.OperatingSystem]::IsWindows())">
+    <VelopackRustOutputDirectory>..\Rust\target\$(Configuration.ToLower())</VelopackRustOutputDirectory>
+    <VelopackUpdateExe>update.exe</VelopackUpdateExe>
+    <VelopackStubExe>stub.exe</VelopackStubExe>
+    <VelopackSetupExe>setup.exe</VelopackSetupExe>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([System.OperatingSystem]::IsWindows())">
+    <None Include="..\Rust\target\$(Configuration.ToLower())\$(VelopackUpdateExe)" Link="$(VelopackUpdateExe)" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Rust\target\$(Configuration.ToLower())\$(VelopackStubExe)" Link="$(VelopackStubExe)" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Rust\target\$(Configuration.ToLower())\$(VelopackSetupExe)" Link="$(VelopackSetupExe)" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+
+    <None Include="..\..\vendor\rcedit.exe" Link="rcedit.exe" Visible="false" Condition="$([System.OperatingSystem]::IsWindows())">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\vendor\zstd.exe" Link="zstd.exe" Visible="false" Condition="$([System.OperatingSystem]::IsWindows())">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
+  <ItemGroup Label="NuGet">
+    <None Include="Velopack.Build.targets" Pack="true" PackagePath="build\Velopack.Build.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.9.5" />
+  </ItemGroup>
+</Project>

--- a/src/Velopack.Build/Velopack.Build.targets
+++ b/src/Velopack.Build/Velopack.Build.targets
@@ -1,0 +1,73 @@
+<Project>
+  <PropertyGroup>
+    <!-- 
+    TODO: Should we default this to false? 
+    Is the action of adding the NuGet package sufficient to assume the user wants this to always 
+    create a release on publish? 
+    -->
+    <VelopackPackOnPublish Condition="$(VelopackPackOnPublish) == ''">true</VelopackPackOnPublish>
+    
+    <!-- By default we will push if packing is enabled -->
+    <VelopackPushOnPublish Condition="$(VelopackPushOnPublish) == ''">$(VelopackPackOnPublish)</VelopackPushOnPublish>
+
+    <!-- 
+    https://learn.microsoft.com/visualstudio/msbuild/tutorial-custom-task-code-generation?view=vs-2022&WT.mc_id=DT-MVP-5003472#changes-required-to-multitarget
+    -->
+    <VelopackStronglyTyped_TFM Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net472</VelopackStronglyTyped_TFM>
+    <VelopackStronglyTyped_TFM Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net6.0</VelopackStronglyTyped_TFM>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Velopack.Build.PackTask"
+        AssemblyFile="..\..\build\$(Configuration)\$(VelopackStronglyTyped_TFM)\Velopack.Build.dll"/>
+
+  <UsingTask TaskName="Velopack.Build.PublishTask"
+          AssemblyFile="..\..\build\$(Configuration)\$(VelopackStronglyTyped_TFM)\Velopack.Build.dll"/>
+
+  <Target Name="_VelopackResolveProperties" AfterTargets="Publish" BeforeTargets="VelopackBuildRelease">
+    <PropertyGroup>
+      <VelopackPackVersion Condition="'$(VelopackPackVersion)' == ''">$(Version)</VelopackPackVersion>
+      <VelopackPackId Condition="'$(VelopackPackId)' == ''">$(AssemblyName)</VelopackPackId>
+      <VelopackPackDirectory Condition="'$(VelopackPackDirectory)' == ''">$(PublishDir)</VelopackPackDirectory>
+
+      <!-- TODO: Is there a way to try and determine this from the project? -->
+      <VelopackRuntimes Condition="'$(VelopackRuntimes)' == ''">net8-x64-desktop</VelopackRuntimes>
+
+      <!-- TODO: is this a reasonable default? -->
+      <VelopackReleaseDirectory Condition="'$(VelopackReleaseDirectory)' == ''">releases</VelopackReleaseDirectory>
+    </PropertyGroup>
+
+    <ConvertToAbsolutePath Paths="$(VelopackReleaseDirectory)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="VelopackReleaseDirectory"/>
+    </ConvertToAbsolutePath>
+
+    <ConvertToAbsolutePath Paths="$(VelopackPackDirectory)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="VelopackPackDirectory"/>
+    </ConvertToAbsolutePath>
+  </Target>
+
+  <Target Name="VelopackBuildRelease" AfterTargets="Publish" Condition="'$(VelopackPackOnPublish)' == 'true'">
+    <!-- 
+    TODO: Add additional error checking for the rest of the parameters.
+    -->
+    <Warning Condition="'$(VelopackPackVersion)' == ''"
+             Text="No version specified, Velopack will not publish a release."
+             />
+
+    <PackTask
+      Condition="'$(VelopackPackVersion)' != ''"
+      Runtimes="$(VelopackRuntimes)"
+      PackId="$(VelopackPackId)"
+      ReleaseDirectory="$(VelopackReleaseDirectory)"
+      PackDirectory="$(VelopackPackDirectory)"
+      PackVersion="$(VelopackPackVersion)"
+      />
+  </Target>
+
+  <Target Name="VelopackPushRelease" AfterTargets="VelopackBuildRelease" Condition="'$(VelopackPushOnPublish)' == 'true'">
+    <PublishTask 
+      ReleaseDirectory="$(VelopackReleaseDirectory)"
+      Version="$(VelopackPackVersion)"
+      ServiceUrl="$(VelopackFlowServiceUrl)"
+      />
+  </Target>
+</Project>

--- a/src/Velopack.Build/dev-scripts/build-win.bat
+++ b/src/Velopack.Build/dev-scripts/build-win.bat
@@ -1,0 +1,16 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+echo.
+echo Kill existing MSBuild processes
+taskkill /F /IM MSBuild.exe
+
+echo.
+echo Kill existing dotnet processes
+taskkill /F /IM dotnet.exe
+
+echo.
+echo Building Velopack.Build
+cd %~dp0..\..\..\
+dotnet build -c Debug src/Velopack.Build/Velopack.Build.csproj

--- a/src/Velopack.Deployment/HttpRepository.cs
+++ b/src/Velopack.Deployment/HttpRepository.cs
@@ -19,3 +19,5 @@ public class HttpRepository : SourceRepository<HttpDownloadOptions, SimpleWebSou
         return new SimpleWebSource(options.Url);
     }
 }
+
+

--- a/src/Velopack.Deployment/VelopackRepository.cs
+++ b/src/Velopack.Deployment/VelopackRepository.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using Velopack.NuGet;
+using Velopack.Packaging;
+using Velopack.Sources;
+
+namespace Velopack.Deployment;
+
+
+public class VelopackDownloadOptions : RepositoryOptions
+{
+    public string Version { get; set; }
+}
+
+public class VelopackUploadOptions : VelopackDownloadOptions
+{
+}
+
+public class VelopackRepository : SourceRepository<VelopackDownloadOptions, VelopackFlowUpdateSource>, IRepositoryCanUpload<VelopackUploadOptions>
+{
+    private static HttpClient Client { get; } = new HttpClient {
+        BaseAddress = new Uri("https://velopack.keboo.dev/")
+    };
+
+    public VelopackRepository(ILogger logger)
+        : base(logger)
+    { }
+
+    public override VelopackFlowUpdateSource CreateSource(VelopackDownloadOptions options)
+    {
+        return new VelopackFlowUpdateSource();
+    }
+
+    public async Task UploadMissingAssetsAsync(VelopackUploadOptions options)
+    {
+        var helper = new ReleaseEntryHelper(options.ReleaseDir.FullName, options.Channel, Log);
+        var latest = helper.GetLatestAssets().ToList();
+
+        Log.Info($"Preparing to upload {latest.Count} assets to Velopack");
+
+        foreach (var asset in latest) {
+            
+            var latestPath = Path.Combine(options.ReleaseDir.FullName, asset.FileName);
+            ZipPackage zipPackage = new(latestPath);
+            var semVer = options.Version ?? asset.Version.ToString();
+
+            using var formData = new MultipartFormDataContent
+            {
+                { new StringContent(options.Channel), "Channel" },
+            };
+
+            using var fileStream = File.OpenRead(latestPath);
+            using var fileContent = new StreamContent(fileStream);
+            formData.Add(fileContent, "File", asset.FileName);
+
+            var response = await Client.PostAsync("api/v1/upload", formData);
+            response.EnsureSuccessStatusCode();
+
+            Log.Info($"    Uploaded {asset.FileName} to Velopack");
+        }
+    }
+}

--- a/src/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -135,13 +135,13 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
 
     protected override Task CreateSetupPackage(Action<int> progress, string releasePkg, string packDir, string targetSetupExe)
     {
-        var bundledzp = new ZipPackage(releasePkg);
+        var bundledZip = new ZipPackage(releasePkg);
         Utility.Retry(() => File.Copy(HelperFile.SetupPath, targetSetupExe, true));
         progress(10);
         if (VelopackRuntimeInfo.IsWindows) {
-            Rcedit.SetPEVersionBlockFromPackageInfo(targetSetupExe, bundledzp, Options.Icon);
+            Rcedit.SetPEVersionBlockFromPackageInfo(targetSetupExe, bundledZip, Options.Icon);
         } else {
-            Log.Warn("Unable to set Setup.exe icon (only supported on windows)");
+            Log.Warn("Unable to set PE Version on Setup.exe (only supported on windows)");
         }
         progress(25);
         Log.Debug($"Creating Setup bundle");

--- a/src/Velopack.Packaging.Windows/SetupBundle.cs
+++ b/src/Velopack.Packaging.Windows/SetupBundle.cs
@@ -21,16 +21,16 @@ public static class SetupBundle
 
         void FindBundleHeader()
         {
-            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(setupPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read))
-            using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read)) {
-                int position = BinaryUtils.SearchInFile(accessor, bundleSignature);
-                if (position == -1) {
-                    throw new PlaceHolderNotFoundInAppHostException(bundleSignature);
-                }
+            using var memoryMappedFile = MemoryMappedFile.CreateFromFile(setupPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
 
-                offset = accessor.ReadInt64(position - 16);
-                length = accessor.ReadInt64(position - 8);
+            int position = BinaryUtils.SearchInFile(accessor, bundleSignature);
+            if (position == -1) {
+                throw new PlaceHolderNotFoundInAppHostException(bundleSignature);
             }
+
+            offset = accessor.ReadInt64(position - 16);
+            length = accessor.ReadInt64(position - 8);
         }
 
         Utility.Retry(FindBundleHeader);
@@ -53,8 +53,8 @@ public static class SetupBundle
             bundleLength = pkgStream.Length;
             pkgStream.CopyTo(setupStream);
         } finally {
-            if (pkgStream != null) pkgStream.Dispose();
-            if (setupStream != null) setupStream.Dispose();
+            pkgStream?.Dispose();
+            setupStream?.Dispose();
         }
 
         byte[] placeholder = {

--- a/src/Velopack.Packaging/Abstractions/ICommand.cs
+++ b/src/Velopack.Packaging/Abstractions/ICommand.cs
@@ -1,4 +1,4 @@
-﻿namespace Velopack.Packaging.Abstractions;
+namespace Velopack.Packaging.Abstractions;
 
 public interface ICommand<TOpt> where TOpt : class
 {

--- a/src/Velopack.Packaging/Abstractions/IConsole.cs
+++ b/src/Velopack.Packaging/Abstractions/IConsole.cs
@@ -1,0 +1,5 @@
+﻿namespace Velopack.Packaging.Abstractions;
+public interface IConsole
+{
+    void WriteLine(string message = "");
+}

--- a/src/Velopack.Packaging/Abstractions/IFancyConsole.cs
+++ b/src/Velopack.Packaging/Abstractions/IFancyConsole.cs
@@ -1,12 +1,10 @@
 ﻿namespace Velopack.Packaging.Abstractions;
 
-public interface IFancyConsole
+public interface IFancyConsole : IConsole
 {
     Task ExecuteProgressAsync(Func<IFancyConsoleProgress, Task> action);
 
     void WriteTable(string tableName, IEnumerable<IEnumerable<string>> rows, bool hasHeaderRow = true);
 
     Task<bool> PromptYesNo(string prompt, bool? defaultValue = null, TimeSpan? timeout = null);
-
-    void WriteLine(string text = "");
 }

--- a/src/Velopack.Packaging/Abstractions/IPlatformOptions.cs
+++ b/src/Velopack.Packaging/Abstractions/IPlatformOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Velopack.Packaging.Abstractions;
+namespace Velopack.Packaging.Abstractions;
 
 public interface IPlatformOptions : IOutputOptions
 {

--- a/src/Velopack.Packaging/Flow/AuthConfiguration.cs
+++ b/src/Velopack.Packaging/Flow/AuthConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace Velopack.Packaging.Flow;
+
+#nullable enable
+public class AuthConfiguration
+{
+    public string? B2CAuthority { get; set; }
+    public string? RedirectUri { get; set; }
+    public string? ClientId { get; set; }
+}

--- a/src/Velopack.Packaging/Flow/Profile.cs
+++ b/src/Velopack.Packaging/Flow/Profile.cs
@@ -1,0 +1,8 @@
+﻿namespace Velopack.Packaging.Flow;
+
+#nullable enable
+public class Profile
+{
+    public string? Name { get; set; }
+    public string? Email { get; set; }
+}

--- a/src/Velopack.Packaging/Flow/UploadInstallerOptions.cs
+++ b/src/Velopack.Packaging/Flow/UploadInstallerOptions.cs
@@ -1,0 +1,20 @@
+﻿
+#nullable enable
+
+using NuGet.Versioning;
+
+namespace Velopack.Packaging.Flow;
+
+public class UploadInstallerOptions : UploadOptions
+{
+    public string PackageId { get; }
+
+    public SemanticVersion Version { get; }
+
+    public UploadInstallerOptions(string packageId, SemanticVersion version, Stream releaseData, string fileName, string? channel)
+        : base(releaseData, fileName, channel)
+    {
+        PackageId = packageId;
+        Version = version;
+    }
+}

--- a/src/Velopack.Packaging/Flow/UploadOptions.cs
+++ b/src/Velopack.Packaging/Flow/UploadOptions.cs
@@ -1,0 +1,21 @@
+﻿
+#nullable enable
+
+using NuGet.Versioning;
+
+namespace Velopack.Packaging.Flow;
+
+public class UploadOptions : VelopackServiceOptions
+{
+    public Stream ReleaseData { get; }
+    public string FileName { get; }
+    public string? Channel { get; }
+
+    public UploadOptions(Stream releaseData, string fileName, string? channel)
+    {
+        ReleaseData = releaseData;
+        FileName = fileName;
+
+        Channel = channel;
+    }
+}

--- a/src/Velopack.Packaging/Flow/VelopackFlowServiceClient.cs
+++ b/src/Velopack.Packaging/Flow/VelopackFlowServiceClient.cs
@@ -1,0 +1,244 @@
+﻿using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+
+
+using Velopack.Packaging.Abstractions;
+
+#if NET6_0_OR_GREATER
+using System.Net.Http.Json;
+#endif
+
+#nullable enable
+namespace Velopack.Packaging.Flow;
+
+public interface IVelopackFlowServiceClient
+{
+    Task<bool> LoginAsync(VelopackLoginOptions? options = null);
+    Task LogoutAsync(VelopackServiceOptions? options = null);
+
+    Task<Profile?> GetProfileAsync(VelopackServiceOptions? options = null);
+    Task UploadReleaseAssetAsync(UploadOptions options);
+}
+
+public class VelopackFlowServiceClient(HttpClient HttpClient, IConsole Console) : IVelopackFlowServiceClient
+{
+    private static readonly string[] Scopes = ["openid", "offline_access"];
+
+    public bool HasAuthentication => HttpClient.DefaultRequestHeaders.Authorization is not null;
+
+    private AuthConfiguration? AuthConfiguration { get; set; }
+
+    public async Task<bool> LoginAsync(VelopackLoginOptions? options = null)
+    {
+        options ??= new VelopackLoginOptions();
+        Console.WriteLine($"Preparing to login to Velopack ({options.VelopackBaseUrl})");
+
+        var authConfiguration = await GetAuthConfigurationAsync(options);
+
+        var pca = await BuildPublicApplicationAsync(authConfiguration);
+
+        AuthenticationResult? rv = null;
+        if (options.AllowCacheCredentials) {
+            rv = await AcquireSilentlyAsync(pca);
+        }
+        if (rv is null && options.AllowInteractiveLogin) {
+            rv = await AcquireInteractiveAsync(pca, authConfiguration);
+        }
+        if (rv is null && options.AllowDeviceCodeFlow) {
+            rv = await AcquireByDeviceCodeAsync(pca);
+        }
+
+        if (rv != null) {
+            HttpClient.DefaultRequestHeaders.Authorization = new("Bearer", rv.IdToken ?? rv.AccessToken);
+            var profile = await GetProfileAsync(options);
+
+            Console.WriteLine($"{profile?.Name} logged into Velopack");
+            return true;
+        } else {
+            Console.WriteLine("Failed to login to Velopack");
+            return false;
+        }
+    }
+
+    public async Task LogoutAsync(VelopackServiceOptions? options = null)
+    {
+        var authConfiguration = await GetAuthConfigurationAsync(options);
+
+        var pca = await BuildPublicApplicationAsync(authConfiguration);
+
+        // clear the cache
+        while ((await pca.GetAccountsAsync()).FirstOrDefault() is { } account) {
+            await pca.RemoveAsync(account);
+            Console.WriteLine($"Logged out of {account.Username}");
+        }
+        Console.WriteLine("Cleared saved login(s) for Velopack");
+    }
+
+    public async Task<Profile?> GetProfileAsync(VelopackServiceOptions? options = null)
+    {
+        AssertAuthenticated();
+        var endpoint = GetEndpoint("/api/v1/user/profile", options);
+
+        return await HttpClient.GetFromJsonAsync<Profile>(endpoint);
+    }
+
+    public async Task UploadReleaseAssetAsync(UploadOptions options)
+    {
+        AssertAuthenticated();
+
+        using var formData = new MultipartFormDataContent
+        {
+            { new StringContent(options.Channel ?? ""), "Channel" }
+        };
+
+        using var fileContent = new StreamContent(options.ReleaseData);
+        formData.Add(fileContent, "File", options.FileName);
+
+        var endpoint = GetEndpoint("api/v1/upload-release", options);
+
+        var response = await HttpClient.PostAsync(endpoint, formData);
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task UploadInstallerAssetAsync(UploadInstallerOptions options)
+    {
+        AssertAuthenticated();
+
+        using var formData = new MultipartFormDataContent
+        {
+            { new StringContent(options.PackageId ?? ""), "PackageId" },
+            { new StringContent(options.Channel ?? ""), "Channel" },
+            { new StringContent(options.Version.ToNormalizedString() ?? ""), "Version" },
+        };
+
+        using var fileContent = new StreamContent(options.ReleaseData);
+        formData.Add(fileContent, "File", options.FileName);
+
+        var endpoint = GetEndpoint("api/v1/upload-installer", options);
+
+        var response = await HttpClient.PostAsync(endpoint, formData);
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<AuthConfiguration> GetAuthConfigurationAsync(VelopackServiceOptions? options)
+    {
+        if (AuthConfiguration is not null)
+            return AuthConfiguration;
+
+        var endpoint = GetEndpoint("/api/v1/auth/config", options);
+
+        var authConfig = await HttpClient.GetFromJsonAsync<AuthConfiguration>(endpoint);
+        if (authConfig is null)
+            throw new Exception("Failed to get auth configuration.");
+        if (authConfig.B2CAuthority is null)
+            throw new Exception("B2C Authority not provided.");
+        if (authConfig.RedirectUri is null)
+            throw new Exception("Redirect URI not provided.");
+        if (authConfig.ClientId is null)
+            throw new Exception("Client ID not provided.");
+
+        return authConfig;
+    }
+
+    private static Uri GetEndpoint(string relativePath, VelopackServiceOptions? options)
+    {
+        var baseUrl = options?.VelopackBaseUrl ?? VelopackServiceOptions.DefaultBaseUrl;
+        var endpoint = new Uri(relativePath, UriKind.Relative);
+        return new(new Uri(baseUrl), endpoint);
+    }
+
+    private void AssertAuthenticated()
+    {
+        if (!HasAuthentication) {
+            throw new InvalidOperationException($"{nameof(VelopackFlowServiceClient)} has not been authenticated, call {nameof(LoginAsync)} first.");
+        }
+    }
+
+    private static async Task<AuthenticationResult?> AcquireSilentlyAsync(IPublicClientApplication pca)
+    {
+        foreach (var account in await pca.GetAccountsAsync()) {
+            try {
+                if (account is not null) {
+                    return await pca.AcquireTokenSilent(Scopes, account)
+                        .ExecuteAsync();
+                }
+            } catch (MsalException) {
+                await pca.RemoveAsync(account);
+                // No token found in the cache or Azure AD insists that a form interactive auth is required (e.g. the tenant admin turned on MFA)
+            }
+        }
+        return null;
+    }
+
+    private static async Task<AuthenticationResult?> AcquireInteractiveAsync(IPublicClientApplication pca, AuthConfiguration authConfiguration)
+    {
+        try {
+            return await pca.AcquireTokenInteractive(Scopes)
+                        .WithB2CAuthority(authConfiguration.B2CAuthority)
+                        .ExecuteAsync();
+        } catch (MsalException) {
+        }
+        return null;
+    }
+
+    private async Task<AuthenticationResult?> AcquireByDeviceCodeAsync(IPublicClientApplication pca)
+    {
+        try {
+            var result = await pca.AcquireTokenWithDeviceCode(Scopes,
+                deviceCodeResult => {
+                    // This will print the message on the logger which tells the user where to go sign-in using 
+                    // a separate browser and the code to enter once they sign in.
+                    // The AcquireTokenWithDeviceCode() method will poll the server after firing this
+                    // device code callback to look for the successful login of the user via that browser.
+                    // This background polling (whose interval and timeout data is also provided as fields in the 
+                    // deviceCodeCallback class) will occur until:
+                    // * The user has successfully logged in via browser and entered the proper code
+                    // * The timeout specified by the server for the lifetime of this code (typically ~15 minutes) has been reached
+                    // * The developing application calls the Cancel() method on a CancellationToken sent into the method.
+                    //   If this occurs, an OperationCanceledException will be thrown (see catch below for more details).
+                    Console.WriteLine(deviceCodeResult.Message);
+                    return Task.FromResult(0);
+                }).ExecuteAsync();
+
+            Console.WriteLine(result.Account.Username);
+            return result;
+        } catch (MsalException) {
+        }
+        return null;
+    }
+
+    private static async Task<IPublicClientApplication> BuildPublicApplicationAsync(AuthConfiguration authConfiguration)
+    {
+        //https://learn.microsoft.com/entra/msal/dotnet/how-to/token-cache-serialization?tabs=desktop&WT.mc_id=DT-MVP-5003472
+        var userPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var vpkPath = Path.Combine(userPath, ".vpk");
+
+        var storageProperties =
+             new StorageCreationPropertiesBuilder("creds.bin", vpkPath)
+             .WithLinuxKeyring(
+                 schemaName: "com.velopack.app",
+                 collection: "default",
+                 secretLabel: "Credentials for Velopack",
+                 new KeyValuePair<string, string>("vpk.client-id", authConfiguration.ClientId ?? ""),
+                 new KeyValuePair<string, string>("vpk.version", "v1")
+              )
+             .WithMacKeyChain(
+                 serviceName: "velopack",
+                 accountName: "vpk")
+             .Build();
+        var cacheHelper = await MsalCacheHelper.CreateAsync(storageProperties);
+
+        var pca = PublicClientApplicationBuilder
+                .Create(authConfiguration.ClientId)
+                .WithB2CAuthority(authConfiguration.B2CAuthority)
+                .WithRedirectUri(authConfiguration.RedirectUri)
+                //.WithLogging((LogLevel level, string message, bool containsPii) => System.Console.WriteLine($"[{level}]: {message}"))
+                .WithClientName("velopack")
+                .Build();
+
+        cacheHelper.RegisterCache(pca.UserTokenCache);
+        return pca;
+    }
+}

--- a/src/Velopack.Packaging/Flow/VelopackLoginOptions.cs
+++ b/src/Velopack.Packaging/Flow/VelopackLoginOptions.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+namespace Velopack.Packaging.Flow;
+
+public class VelopackLoginOptions : VelopackServiceOptions
+{
+    public bool AllowCacheCredentials { get; set; } = true;
+    public bool AllowInteractiveLogin { get; set; } = true;
+    public bool AllowDeviceCodeFlow { get; set; } = true;
+}

--- a/src/Velopack.Packaging/Flow/VelopackServiceOptions.cs
+++ b/src/Velopack.Packaging/Flow/VelopackServiceOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Velopack.Packaging.Flow;
+
+public class VelopackServiceOptions
+{
+    public const string DefaultBaseUrl = "https://api.velopack.io/";
+
+    public string VelopackBaseUrl { get; set; } = DefaultBaseUrl;
+}

--- a/src/Velopack.Packaging/HttpClientExtensions.cs
+++ b/src/Velopack.Packaging/HttpClientExtensions.cs
@@ -1,0 +1,19 @@
+﻿#if NETSTANDARD2_0
+
+#nullable enable
+namespace Velopack.Packaging;
+
+public static class HttpClientExtensions
+{
+    public static async Task<TValue?> GetFromJsonAsync<TValue>(
+        this HttpClient client, 
+        Uri? requestUri, 
+        CancellationToken cancellationToken = default)
+    {
+        var response = await client.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return Newtonsoft.Json.JsonConvert.DeserializeObject<TValue>(await response.Content.ReadAsStringAsync());
+    }
+}
+#endif

--- a/src/Velopack.Packaging/Velopack.Packaging.csproj
+++ b/src/Velopack.Packaging/Velopack.Packaging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
@@ -14,6 +14,9 @@
   <ItemGroup>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Markdig" Version="0.34.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.59.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.59.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.59.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Velopack.Vpk/Commands/LoginCommand.cs
+++ b/src/Velopack.Vpk/Commands/LoginCommand.cs
@@ -1,0 +1,10 @@
+﻿namespace Velopack.Vpk.Commands;
+public class LoginCommand : VelopackServiceCommand
+{
+    public LoginCommand()
+        : base("login", "Login to Velopack's hosted service.")
+    {
+        //Just hiding this for now as it is not ready for mass consumption.
+        Hidden = true;
+    }
+}

--- a/src/Velopack.Vpk/Commands/LoginCommandRunner.cs
+++ b/src/Velopack.Vpk/Commands/LoginCommandRunner.cs
@@ -1,0 +1,16 @@
+﻿using Velopack.Packaging.Abstractions;
+using Velopack.Packaging.Flow;
+
+namespace Velopack.Vpk.Commands;
+#nullable enable
+
+public class LoginCommandRunner(IVelopackFlowServiceClient Client) : ICommand<LoginOptions>
+{
+
+    public async Task Run(LoginOptions options)
+    {
+        await Client.LoginAsync(new() {
+            VelopackBaseUrl = options.VelopackBaseUrl
+        });
+    }
+}

--- a/src/Velopack.Vpk/Commands/LoginOptions.cs
+++ b/src/Velopack.Vpk/Commands/LoginOptions.cs
@@ -1,0 +1,5 @@
+﻿using Velopack.Packaging.Flow;
+
+namespace Velopack.Vpk.Commands;
+
+public sealed class LoginOptions: VelopackServiceOptions;

--- a/src/Velopack.Vpk/Commands/LogoutCommand.cs
+++ b/src/Velopack.Vpk/Commands/LogoutCommand.cs
@@ -1,0 +1,10 @@
+﻿namespace Velopack.Vpk.Commands;
+public class LogoutCommand : VelopackServiceCommand
+{
+    public LogoutCommand()
+        : base("logout", "Remove any stored credential to the Velopack service.")
+    {
+        //Just hiding this for now as it is not ready for mass consumption.
+        Hidden = true;
+    }
+}

--- a/src/Velopack.Vpk/Commands/LogoutCommandRunner.cs
+++ b/src/Velopack.Vpk/Commands/LogoutCommandRunner.cs
@@ -1,0 +1,13 @@
+﻿using Velopack.Packaging.Abstractions;
+using Velopack.Packaging.Flow;
+
+#nullable enable
+namespace Velopack.Vpk.Commands;
+
+internal class LogoutCommandRunner(IVelopackFlowServiceClient Client) : ICommand<LogoutOptions>
+{
+    public async Task Run(LogoutOptions options)
+    {
+        await Client.LogoutAsync(options);
+    }
+}

--- a/src/Velopack.Vpk/Commands/LogoutOptions.cs
+++ b/src/Velopack.Vpk/Commands/LogoutOptions.cs
@@ -1,0 +1,5 @@
+﻿using Velopack.Packaging.Flow;
+
+namespace Velopack.Vpk.Commands;
+
+public sealed class LogoutOptions: VelopackServiceOptions;

--- a/src/Velopack.Vpk/Commands/LongHelpCommand.cs
+++ b/src/Velopack.Vpk/Commands/LongHelpCommand.cs
@@ -142,7 +142,7 @@ public class LongHelpCommand : CliOption<bool>
                 output.Add(Text.NewLine);
 
                 var commandsTable = CreateTable();
-                foreach (var cmd in command.Subcommands) {
+                foreach (var cmd in command.Subcommands.Where(x => !x.Hidden)) {
                     var columns = GetTwoColumnRowCommand(cmd);
                     commandsTable.AddRow(new Markup($"[bold]{columns.FirstColumnText}[/]"), new Text(columns.SecondColumnText));
                 }
@@ -154,7 +154,7 @@ public class LongHelpCommand : CliOption<bool>
             return 0;
         }
 
-        public TwoColumnHelpRow GetTwoColumnRowCommand(CliCommand command)
+        public static TwoColumnHelpRow GetTwoColumnRowCommand(CliCommand command)
         {
             if (command is null) {
                 throw new ArgumentNullException(nameof(command));
@@ -165,7 +165,7 @@ public class LongHelpCommand : CliOption<bool>
             return new TwoColumnHelpRow(firstColumnText, secondColumnText);
         }
 
-        public TwoColumnHelpRow GetTwoColumnRowOption(CliOption symbol)
+        public static TwoColumnHelpRow GetTwoColumnRowOption(CliOption symbol)
         {
             if (symbol is null) {
                 throw new ArgumentNullException(nameof(symbol));
@@ -187,7 +187,7 @@ public class LongHelpCommand : CliOption<bool>
             return new TwoColumnHelpRow(firstColumnText, secondColumnText);
         }
 
-        private string GetUsage(CliCommand command)
+        private static string GetUsage(CliCommand command)
         {
             return string.Join(" ", GetUsageParts().Where(x => !string.IsNullOrWhiteSpace(x)));
 
@@ -230,7 +230,7 @@ public class LongHelpCommand : CliOption<bool>
             }
         }
 
-        private string FormatArgumentUsage(IList<CliArgument> arguments)
+        private static string FormatArgumentUsage(IList<CliArgument> arguments)
         {
             var sb = new StringBuilder(arguments.Count * 100);
 
@@ -281,7 +281,7 @@ public class LongHelpCommand : CliOption<bool>
 public static class HelpExtensions
 {
     public static bool HasArguments(this CliCommand command) => command.Arguments?.Count > 0;
-    public static bool HasSubcommands(this CliCommand command) => command.Subcommands?.Count > 0;
+    public static bool HasSubcommands(this CliCommand command) => command.Subcommands?.Where(x => !x.Hidden).Any() == true;
     public static bool HasOptions(this CliCommand command) => command.Options?.Count > 0;
 
     internal static IEnumerable<T> RecurseWhileNotNull<T>(

--- a/src/Velopack.Vpk/Commands/VelopackBaseCommand.cs
+++ b/src/Velopack.Vpk/Commands/VelopackBaseCommand.cs
@@ -1,0 +1,32 @@
+﻿namespace Velopack.Vpk.Commands;
+#nullable enable
+
+public abstract class VelopackBaseCommand : OutputCommand
+{
+    public string? TeamName { get; private set; }
+
+    public string? ProjectName { get; private set; }
+
+    protected VelopackBaseCommand(string name, string description) 
+        : base(name, description)
+    {
+        AddOption<string>((v) => TeamName = v, "--team-name", "-t")
+            .SetDescription("The name of the team")
+            .SetRequired();
+
+        AddOption<string>((v) => ProjectName = v, "--project-name", "-p")
+            .SetDescription("The name of the project")
+            .SetRequired();
+    }
+}
+
+public class VelopackPublishCommand : VelopackBaseCommand
+{
+    public string? Version { get; set; }
+
+    public VelopackPublishCommand()
+        : base ("publish", "Uploads a release to Velopack's hosted service")
+    {
+        
+    }
+}

--- a/src/Velopack.Vpk/Commands/VelopackServiceCommand.cs
+++ b/src/Velopack.Vpk/Commands/VelopackServiceCommand.cs
@@ -1,0 +1,17 @@
+﻿using Velopack.Packaging.Flow;
+
+namespace Velopack.Vpk.Commands;
+
+public abstract class VelopackServiceCommand : BaseCommand
+{
+    public string VelopackBaseUrl { get; private set; }
+
+    protected VelopackServiceCommand(string name, string description)
+        : base(name, description)
+    {
+        AddOption<string>(v => VelopackBaseUrl = v, "--baseUrl")
+            .SetDescription("The base Uri for the Velopack API service.")
+            .SetArgumentHelpName("URI")
+            .SetDefault(VelopackServiceOptions.DefaultBaseUrl);
+    }
+}

--- a/src/Velopack.Vpk/OptionMapper.cs
+++ b/src/Velopack.Vpk/OptionMapper.cs
@@ -1,4 +1,4 @@
-﻿using Riok.Mapperly.Abstractions;
+using Riok.Mapperly.Abstractions;
 using Velopack.Deployment;
 using Velopack.Packaging.Commands;
 using Velopack.Packaging.Unix.Commands;
@@ -26,6 +26,9 @@ public static partial class OptionMapper
     public static partial S3UploadOptions ToOptions(this S3UploadCommand cmd);
     public static partial DeltaGenOptions ToOptions(this DeltaGenCommand cmd);
     public static partial DeltaPatchOptions ToOptions(this DeltaPatchCommand cmd);
+    public static partial LoginOptions ToOptions(this LoginCommand cmd);
+    public static partial LogoutOptions ToOptions(this LogoutCommand cmd);
+    public static partial VelopackUploadOptions ToOptions(this VelopackPublishCommand cmd);
 
     private static DirectoryInfo StringToDirectoryInfo(string t)
     {

--- a/src/Velopack.Vpk/Velopack.Vpk.csproj
+++ b/src/Velopack.Vpk/Velopack.Vpk.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />

--- a/src/Velopack/Internal/SimpleJson.cs
+++ b/src/Velopack/Internal/SimpleJson.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NuGet.Versioning;
 
 #if NET5_0_OR_GREATER

--- a/src/Velopack/Internal/Utility.cs
+++ b/src/Velopack/Internal/Utility.cs
@@ -486,8 +486,7 @@ namespace Velopack
 
         public static bool IsHttpUrl(string urlOrPath)
         {
-            var uri = default(Uri);
-            if (!Uri.TryCreate(urlOrPath, UriKind.Absolute, out uri)) {
+            if (!Uri.TryCreate(urlOrPath, UriKind.Absolute, out Uri? uri)) {
                 return false;
             }
 

--- a/src/Velopack/Sources/GitBase.cs
+++ b/src/Velopack/Sources/GitBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -64,7 +64,7 @@ namespace Velopack.Sources
         public virtual async Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
         {
             var releases = await GetReleases(Prerelease).ConfigureAwait(false);
-            if (releases == null || releases.Count() == 0) {
+            if (releases == null || releases.Length == 0) {
                 logger.Warn($"No releases found at '{RepoUri}'.");
                 return new VelopackAssetFeed();
             }

--- a/src/Velopack/Sources/GithubSource.cs
+++ b/src/Velopack/Sources/GithubSource.cs
@@ -18,7 +18,7 @@ namespace Velopack.Sources
         [JsonPropertyName("prerelease")]
         public bool Prerelease { get; set; }
 
-        /// <summary> The date which this release was published publically. </summary>
+        /// <summary> The date which this release was published publicly. </summary>
         [JsonPropertyName("published_at")]
         public DateTime? PublishedAt { get; set; }
 

--- a/src/Velopack/Sources/GitlabSource.cs
+++ b/src/Velopack/Sources/GitlabSource.cs
@@ -25,7 +25,7 @@ namespace Velopack.Sources
         public bool UpcomingRelease { get; set; }
 
         /// <summary>
-        /// The date which this release was published publically.
+        /// The date which this release was published publicly.
         /// </summary>
         [JsonPropertyName("released_at")]
         public DateTime? ReleasedAt { get; set; }

--- a/src/Velopack/Sources/IFileDownloader.cs
+++ b/src/Velopack/Sources/IFileDownloader.cs
@@ -15,7 +15,7 @@ namespace Velopack.Sources
         /// <param name="url">The url which will be downloaded.</param>
         /// <param name="targetFile">
         /// The local path where the file will be stored
-        /// If a file exists at this path, it will be overritten.</param>
+        /// If a file exists at this path, it will be overwritten.</param>
         /// <param name="progress">
         /// A delegate for reporting download progress, with expected values from 0-100.
         /// </param>

--- a/src/Velopack/Sources/IUpdateSource.cs
+++ b/src/Velopack/Sources/IUpdateSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Velopack/Sources/SimpleFileSource.cs
+++ b/src/Velopack/Sources/SimpleFileSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;

--- a/src/Velopack/Sources/VelopackFlowUpdateSource.cs
+++ b/src/Velopack/Sources/VelopackFlowUpdateSource.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Velopack.Json;
+using Velopack.Locators;
+
+namespace Velopack.Sources
+{
+    /// <summary>
+    /// Retrieves updates from the hosted Velopack service. 
+    /// </summary>
+    public sealed class VelopackFlowUpdateSource : IUpdateSource
+    {
+        /// <inheritdoc cref="SimpleWebSource" />
+        public VelopackFlowUpdateSource(
+            string baseUri = "https://api.velopack.io/",
+            IFileDownloader? downloader = null)
+        {
+            BaseUri = new Uri(baseUri);
+            Downloader = downloader ?? Utility.CreateDefaultDownloader();
+        }
+
+        /// <summary> The URL of the server hosting packages to update to. </summary>
+        public Uri BaseUri { get; }
+
+        /// <summary> The <see cref="IFileDownloader"/> to be used for performing http requests. </summary>
+        public IFileDownloader Downloader { get; }
+
+        /// <inheritdoc />
+        public async Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, 
+            VelopackAsset? latestLocalRelease = null)
+        {
+            Uri baseUri = new(BaseUri, $"api/v1.0/manifest/");
+            var uri = Utility.AppendPathToUri(baseUri, Utility.GetVeloReleaseIndexName(channel));
+            var args = new Dictionary<string, string>();
+
+            if (VelopackRuntimeInfo.SystemArch != RuntimeCpu.Unknown) {
+                args.Add("arch", VelopackRuntimeInfo.SystemArch.ToString());
+            }
+
+            if (VelopackRuntimeInfo.SystemOs != RuntimeOs.Unknown) {
+                args.Add("os", VelopackRuntimeInfo.SystemOs.GetOsShortName());
+                args.Add("rid", VelopackRuntimeInfo.SystemRid);
+            }
+
+            if (latestLocalRelease != null) {
+                args.Add("id", latestLocalRelease.PackageId);
+                args.Add("localVersion", latestLocalRelease.Version.ToString());
+            } else {
+                args.Add("id", VelopackLocator.GetDefault(logger).AppId ?? "");
+            }
+
+            var uriAndQuery = Utility.AddQueryParamsToUri(uri, args);
+
+            logger.Info($"Downloading releases from '{uriAndQuery}'.");
+
+            var json = await Downloader.DownloadString(uriAndQuery.ToString()).ConfigureAwait(false);
+
+            var releaseAssets = SimpleJson.DeserializeObject<VelopackReleaseAsset[]>(json);
+            return new VelopackAssetFeed() {
+                Assets = releaseAssets
+            };
+        }
+
+        /// <inheritdoc />
+        public async Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken = default)
+        {
+            if (releaseEntry is null) throw new ArgumentNullException(nameof(releaseEntry));
+            if (releaseEntry is not VelopackReleaseAsset velopackRelease) {
+                throw new ArgumentException($"Expected {nameof(releaseEntry)} to be {nameof(VelopackReleaseAsset)} but was {releaseEntry.GetType().FullName}");
+            }
+            if (localFile is null) throw new ArgumentNullException(nameof(localFile));
+
+            Uri sourceBaseUri = Utility.EnsureTrailingSlash(BaseUri);
+
+            Uri downloadUri = new(sourceBaseUri, $"api/v1.0/download/{velopackRelease.Id}");
+
+            logger.Info($"Downloading '{releaseEntry.FileName}' from '{downloadUri}'.");
+            await Downloader.DownloadFile(downloadUri.AbsoluteUri, localFile, progress, cancelToken: cancelToken).ConfigureAwait(false);
+        }
+    }
+
+    internal record VelopackReleaseAsset : VelopackAsset
+    {
+        public string? Id { get; init; }
+    }
+}

--- a/src/Velopack/VelopackRuntimeInfo.cs
+++ b/src/Velopack/VelopackRuntimeInfo.cs
@@ -142,7 +142,7 @@ namespace Velopack
             VelopackDisplayVersion = VelopackNugetVersion.ToNormalizedString() + (VelopackNugetVersion.IsPrerelease ? " (prerelease)" : "");
 #pragma warning restore CS0612
 
-            // get real cpu architecture, even when virtualised by Wow64
+            // get real cpu architecture, even when virtualized by Wow64
 #if NETFRAMEWORK
             CheckArchitectureWindows();
 #else
@@ -216,7 +216,7 @@ namespace Velopack
             SystemOs = RuntimeOs.Windows;
 
             // find the actual OS architecture. We can't rely on the framework alone for this on Windows
-            // because Wow64 virtualisation is good enough to trick us to believing we're running natively
+            // because Wow64 virtualization is good enough to trick us to believing we're running natively
             // in some cases unless we use functions that are not virtualized (such as IsWow64Process2)
 
             try {

--- a/test/Divergic.Logging.Xunit/Divergic.Logging.Xunit.csproj
+++ b/test/Divergic.Logging.Xunit/Divergic.Logging.Xunit.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="System.Text.Json" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.2" />
 		<PackageReference Include="Xunit.Abstractions" Version="2.0.3" />
 	</ItemGroup>
 

--- a/test/Velopack.Packaging.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Packaging.Tests/WindowsPackTests.cs
@@ -346,7 +346,7 @@ public class WindowsPackTests
         new DeltaPatchCommandRunner(logger, new BasicConsole(logger, new DefaultPromptValueFactory(false))).Run(new DeltaPatchOptions {
             BasePackage = Path.Combine(releaseDir, $"{id}-1.0.0-full.nupkg"),
             OutputFile = output,
-            PatchFiles = new[] { new FileInfo(deltaPath), new FileInfo(deltav3) },
+            PatchFiles = [new FileInfo(deltaPath), new FileInfo(deltav3)],
         }).GetAwaiterResult();
 
         // are the packages the same?
@@ -373,7 +373,7 @@ public class WindowsPackTests
 
         // install app
         var setupPath1 = Path.Combine(releaseDir, $"{id}-win-Setup.exe");
-        RunNoCoverage(setupPath1, new string[] { "--nocolor", "--installto", installDir },
+        RunNoCoverage(setupPath1, ["--nocolor", "--installto", installDir],
             Environment.GetFolderPath(Environment.SpecialFolder.Desktop), logger);
 
         var argsPath = Path.Combine(installDir, "args.txt");
@@ -388,8 +388,8 @@ public class WindowsPackTests
         PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger);
 
         // install v2
-        RunCoveredDotnet(appPath, new string[] { "download", releaseDir }, installDir, logger);
-        RunCoveredDotnet(appPath, new string[] { "apply", releaseDir }, installDir, logger, exitCode: null);
+        RunCoveredDotnet(appPath, ["download", releaseDir], installDir, logger);
+        RunCoveredDotnet(appPath, ["apply", releaseDir], installDir, logger, exitCode: null);
 
         Thread.Sleep(2000);
 
@@ -404,7 +404,7 @@ public class WindowsPackTests
         Assert.Equal("2.0.0,test,args !!", File.ReadAllText(restartedPath).Trim());
 
         var updatePath = Path.Combine(installDir, "Update.exe");
-        RunNoCoverage(updatePath, new string[] { "--nocolor", "--silent", "--uninstall" }, Environment.CurrentDirectory, logger);
+        RunNoCoverage(updatePath, ["--nocolor", "--silent", "--uninstall"], Environment.CurrentDirectory, logger);
     }
 
     [SkippableFact]
@@ -550,7 +550,7 @@ public class WindowsPackTests
 
     //private string RunCoveredRust(string binName, string[] args, string workingDir, ILogger logger, int? exitCode = 0)
     //{
-    //    var outputfile = GetPath($"coverage.runrust.{RandomString(8)}.xml");
+    //    var outputFile = GetPath($"coverage.runrust.{RandomString(8)}.xml");
     //    var manifestFile = GetPath("..", "src", "Rust", "Cargo.toml");
 
     //    var psi = new ProcessStartInfo("cargo");
@@ -565,7 +565,7 @@ public class WindowsPackTests
     //    psi.ArgumentList.Add("--manifest-path");
     //    psi.ArgumentList.Add(manifestFile);
     //    psi.ArgumentList.Add("--output");
-    //    psi.ArgumentList.Add(outputfile);
+    //    psi.ArgumentList.Add(outputFile);
     //    psi.ArgumentList.Add("--bin");
     //    psi.ArgumentList.Add(binName);
     //    psi.ArgumentList.Add("--");
@@ -579,7 +579,7 @@ public class WindowsPackTests
         //logger.Info($"TEST: Running {psi.FileName} {psi.ArgumentList.Aggregate((a, b) => $"{a} {b}")}");
         //using var p = Process.Start(psi);
 
-        var outputfile = PathHelper.GetTestRootPath($"run.{RandomString(8)}.log");
+        var outputFile = PathHelper.GetTestRootPath($"run.{RandomString(8)}.log");
 
         try {
             // this is a huge hack, but WaitForProcess hangs in the test runner when the output is redirected
@@ -591,7 +591,7 @@ public class WindowsPackTests
             var fix = new ProcessStartInfo("cmd.exe");
             fix.CreateNoWindow = true;
             fix.WorkingDirectory = psi.WorkingDirectory;
-            fix.Arguments = $"/c \"{psi.FileName}\" {debug} > {outputfile} 2>&1";
+            fix.Arguments = $"/c \"{psi.FileName}\" {debug} > {outputFile} 2>&1";
 
             Stopwatch sw = new Stopwatch();
             sw.Start();
@@ -609,7 +609,7 @@ public class WindowsPackTests
             logger.Info($"TEST: Process exited with code {p.ExitCode} in {elapsed.TotalSeconds}s");
 
             using var fs = Utility.Retry(() => {
-                return File.Open(outputfile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return File.Open(outputFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             }, 10, 1000, logger);
 
             using var reader = new StreamReader(fs);
@@ -633,7 +633,7 @@ public class WindowsPackTests
                 ).Trim();
         } finally {
             try {
-                File.Delete(outputfile);
+                File.Delete(outputFile);
             } catch { }
         }
     }

--- a/test/Velopack.Tests/Velopack.Tests.csproj
+++ b/test/Velopack.Tests/Velopack.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Choose>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">


### PR DESCRIPTION
Velopack.Build adds direct support for automatically building the installers, as well as publish to Velopack's hosted service directly from a `dotnet publish`. Currently leaving this functionality hidden as it is actively being worked on. However, I think this is at a point where we could merge it and start collaborating on the remaining pieces of it.

There are lots of TODOs scattered in this code. I believe I have captured items on the board for each of them to be addressed.

