### PR TITLE
Fix InvalidOperationException when there are no full remote releases

### DIFF
--- a/src/Velopack/Internal/EnumerableExtensions.cs
+++ b/src/Velopack/Internal/EnumerableExtensions.cs
@@ -105,7 +105,7 @@ namespace Velopack
             var result = new List<TSource>();
 
             using (var e = source.GetEnumerator()) {
-                if (!e.MoveNext()) throw new InvalidOperationException("Source sequence doesn't contain any elements.");
+                if (!e.MoveNext()) return result;
 
                 var current = e.Current;
                 var resKey = keySelector(current);

--- a/test/Velopack.Tests/UpdateManagerTests.cs
+++ b/test/Velopack.Tests/UpdateManagerTests.cs
@@ -295,6 +295,18 @@ public class UpdateManagerTests
     }
 
     [Fact]
+    public void CheckFromEmptyFileSource()
+    {
+        using var logger = _output.BuildLoggerFor<UpdateManagerTests>();
+        using var _1 = Utility.GetTempDirectory(out var tempPath);
+        var source = new SimpleFileSource(new DirectoryInfo(tempPath));
+        var locator = new TestVelopackLocator("MyCoolApp", "1.0.0", tempPath, logger);
+        var um = new UpdateManager(source, null, logger, locator);
+        var info = um.CheckForUpdates();
+        Assert.Null(info);
+    }
+
+    [Fact]
     public void NoUpdatesIfCurrentEqualsRemoteVersion()
     {
         using var logger = _output.BuildLoggerFor<UpdateManagerTests>();


### PR DESCRIPTION
UpdateManager.cs:120 has this code:

``` csharp
var latestRemoteFull = feed.Where(r => r.Type == VelopackAssetType.Full).MaxBy(x => x.Version).FirstOrDefault();
if (latestRemoteFull == null) {
    Log.Info("No remote full releases found.");
    return null;
}
```

Clearly the intention here is to just return null if there are no full releases. However, `MaxBy` will instead throw an error because it encounters an empty `IEnumerable`. I think that is a bad idea, because the caller has no chance of checking for that beforehand without causing multiple enumeration. So I changed it to return an empty list instead.

I've also added a Test for the specific case where I encountered this: In an air-gapped environment the updates get put into a folder by the admin manually, however initially that directory might be empty. I'd really like UpdateManager to just not crash, otherwise I'd have to check for this case in my own code, essentially replicating what UpdateManager does, before calling CheckForUpdates().