### PR TITLE
Avoid icon copy failure on WSL

### DIFF
--- a/src/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
+++ b/src/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
@@ -41,8 +41,8 @@ public class LinuxPackCommandRunner : PackageBuilder<LinuxPackOptions>
 
 if [ ! -z "$APPIMAGE" ] && [ ! -z "$APPDIR" ]; then
     MD5=$(echo -n "file://$APPIMAGE" | md5sum | cut -d' ' -f1)
-    cp "$APPDIR/{{iconFilename}}" "$HOME/.cache/thumbnails/normal/$MD5.png"
-    cp "$APPDIR/{{iconFilename}}" "$HOME/.cache/thumbnails/large/$MD5.png"
+    mkdir -p "$HOME/.cache/thumbnails/normal" && cp "$APPDIR/{{iconFilename}}" "$HOME/.cache/thumbnails/normal/$MD5.png"
+    mkdir -p "$HOME/.cache/thumbnails/large" && cp "$APPDIR/{{iconFilename}}" "$HOME/.cache/thumbnails/large/$MD5.png"
     xdg-icon-resource forceupdate
 fi
 


### PR DESCRIPTION
WSL doesn't have these thumbnail directories precreated for you. Since they are per-user, I wonder if even a full ubuntu installation may not always have them precreated for a new user account. Seems like a good idea in general to create the directory whenever necessary.

Fixes #83 