### PR TITLE
Vpk Upload GitHub - add targetCommitish option

### DIFF
--- a/src/Velopack.Deployment/GitHubRepository.cs
+++ b/src/Velopack.Deployment/GitHubRepository.cs
@@ -25,6 +25,8 @@ public class GitHubUploadOptions : GitHubDownloadOptions
 
     public string TagName { get; set; }
 
+    public string TargetCommitish { get; set; }
+
     public bool Merge { get; set; }
 }
 
@@ -92,6 +94,7 @@ public class GitHubRepository : SourceRepository<GitHubDownloadOptions, GithubSo
                 Draft = true,
                 Prerelease = options.Prerelease,
                 Name = string.IsNullOrWhiteSpace(options.ReleaseName) ? semVer.ToString() : options.ReleaseName,
+                TargetCommitish = options.TargetCommitish,
             };
             Log.Info($"Creating draft release titled '{newReleaseReq.Name}'");
             release = await client.Repository.Release.Create(repoOwner, repoName, newReleaseReq);

--- a/src/Velopack.Vpk/Commands/Deployment/GitHubUploadCommand.cs
+++ b/src/Velopack.Vpk/Commands/Deployment/GitHubUploadCommand.cs
@@ -8,6 +8,8 @@ public class GitHubUploadCommand : GitHubBaseCommand
 
     public string TagName { get; private set; }
 
+    public string TargetCommitish { get; private set; }
+
     public bool Prerelease { get; private set; }
 
     public bool Merge { get; private set; }
@@ -31,6 +33,10 @@ public class GitHubUploadCommand : GitHubBaseCommand
         AddOption<string>((v) => TagName = v, "--tag")
             .SetDescription("A custom tag for the release.")
             .SetArgumentHelpName("NAME");
+
+        AddOption<string>((v) => TargetCommitish = v, "--targetCommitish")
+           .SetDescription("A commitish value for tag (branch or commit SHA).")
+           .SetArgumentHelpName("NAME");
 
         ReleaseDirectoryOption.SetRequired();
         ReleaseDirectoryOption.MustNotBeEmpty();

--- a/test/Velopack.CommandLine.Tests/Commands/GitHubCommandTests.cs
+++ b/test/Velopack.CommandLine.Tests/Commands/GitHubCommandTests.cs
@@ -97,4 +97,26 @@ public class GitHubUploadCommandTests : GitHubCommandTests<GitHubUploadCommand>
 
         Assert.Equal("my release", command.ReleaseName);
     }
+
+    [Fact]
+    public void Tag_WithTag_ParsesValue()
+    {
+        var command = new GitHubUploadCommand();
+
+        string cli = GetRequiredDefaultOptions() + $"--tag \"v1.2.3\"";
+        ParseResult parseResult = command.ParseAndApply(cli);
+
+        Assert.Equal("v1.2.3", command.TagName);
+    }
+
+    [Fact]
+    public void TargetCommitish_WithTargetCommitish_ParsesValue()
+    {
+        var command = new GitHubUploadCommand();
+
+        string cli = GetRequiredDefaultOptions() + $"--targetCommitish \"main\"";
+        ParseResult parseResult = command.ParseAndApply(cli);
+
+        Assert.Equal("main", command.TargetCommitish);
+    }
 }


### PR DESCRIPTION
Currently, when creating a new release using the `vpk upload github` command, if the tag doesn't exist, it creates a new tag for the default branch, usually `main` or `master`. In scenarios where creating a beta release from the `develop` branch and setting the tag name to the version generated by an auto-increment tool like GitVersion, a mismatch between the branch and the tag may affect further version calculations. To avoid this, users should define a tag for the `develop` branch themselves and call the upload command with this tag as an option. This PR introduces the `targetCommitish` option, which allows setting from which branch or commit the new tag should be created.