### PR TITLE
Ensure directory path exists when adding a new file during ApplyDeltaPackageFast

### DIFF
--- a/src/Velopack/Compression/DeltaPackage.cs
+++ b/src/Velopack/Compression/DeltaPackage.cs
@@ -76,7 +76,15 @@ namespace Velopack.Compression
                             && !pathsVisited.Contains(DIFF_SUFFIX.Replace(x, ""), StringComparer.InvariantCultureIgnoreCase))
                 .ForEach(x => {
                     Log.Trace($"{x} was in new package but not in old one, adding");
-                    File.Copy(Path.Combine(deltaPath, x), Path.Combine(workingPath, x));
+
+                    string outputFile = Path.Combine(workingPath, x);
+                    string outputDirectory = Path.GetDirectoryName(outputFile)!;
+
+                    if (!Directory.Exists(outputDirectory)) {
+                        Directory.CreateDirectory(outputDirectory);
+                    }
+
+                    File.Copy(Path.Combine(deltaPath, x), outputFile);
                 });
 
             progress(95);


### PR DESCRIPTION
This change handles a case where a file is added in a new version, but the directory path does not exist in the current local version.
Before this change the system would gracefully fallback to pulling the full version download. With this change it will allow the delta patch to be applied and reduces the re-download of the full install.