### PR TITLE
Logging: do not refer to releases.channel.json file as RELEASES; use …

### DIFF
--- a/src/Velopack.Deployment/GitHubRepository.cs
+++ b/src/Velopack.Deployment/GitHubRepository.cs
@@ -62,7 +62,7 @@ public class GitHubRepository : SourceRepository<GitHubDownloadOptions, GithubSo
         var semVer = options.TagName ?? latest.Version.ToString();
         var releaseName = string.IsNullOrWhiteSpace(options.ReleaseName) ? semVer.ToString() : options.ReleaseName;
 
-        Log.Info($"Preparing to upload {build.Files.Count} assets to GitHub");
+        Log.Info($"Preparing to upload {build.Files.Count} asset(s) to GitHub");
 
         var client = new GitHubClient(new ProductHeaderValue("Velopack")) {
             Credentials = new Credentials(options.Token)

--- a/src/Velopack.Deployment/_ObjectRepository.cs
+++ b/src/Velopack.Deployment/_ObjectRepository.cs
@@ -50,16 +50,17 @@ public abstract class ObjectRepository<TDown, TUp, TClient> : DownRepository<TDo
     {
         var build = BuildAssets.Read(options.ReleaseDir.FullName, options.Channel);
         var client = CreateClient(options);
+        var releasesFilename = Path.GetFileName(options.ReleaseDir.FullName);
 
-        Log.Info($"Preparing to upload {build.Files.Count} local assets.");
+        Log.Info($"Preparing to upload {build.Files.Count} local asset(s).");
 
         var remoteReleases = await GetReleasesAsync(options);
-        Log.Info($"There are {remoteReleases.Assets.Length} assets in remote RELEASES file.");
+        Log.Info($"There are {remoteReleases.Assets.Length} asset(s) in remote releases file '{releasesFilename}'.");
 
         var localEntries = build.GetReleaseEntries();
         var releaseEntries = ReleaseEntryHelper.MergeAssets(localEntries, remoteReleases.Assets).ToArray();
 
-        Log.Info($"{releaseEntries.Length} merged local/remote releases.");
+        Log.Info($"{releaseEntries.Length} merged local/remote release(s).");
 
         var toDelete = new VelopackAsset[0];
 
@@ -74,9 +75,9 @@ public abstract class ObjectRepository<TDown, TUp, TClient> : DownRepository<TDo
                     .Where(x => x.Version < minVersion)
                     .ToArray();
                 releaseEntries = releaseEntries.Except(toDelete).ToArray();
-                Log.Info($"Retention policy (keepMaxReleases={options.KeepMaxReleases}) will delete {toDelete.Length} releases.");
+                Log.Info($"Retention policy (keepMaxReleases={options.KeepMaxReleases}) will delete {toDelete.Length} release(s).");
             } else {
-                Log.Info($"Retention policy (keepMaxReleases={options.KeepMaxReleases}) will not be applied, because there will only be {fullReleases.Length} full releases when this upload has completed.");
+                Log.Info($"Retention policy (keepMaxReleases={options.KeepMaxReleases}) will not be applied, because there will only be {fullReleases.Length} full release(s) when this upload has completed.");
             }
         }
 
@@ -101,7 +102,7 @@ public abstract class ObjectRepository<TDown, TUp, TClient> : DownRepository<TDo
 #pragma warning restore CS0612 // Type or member is obsolete
 
         if (toDelete.Length > 0) {
-            Log.Info($"Retention policy about to delete {toDelete.Length} releases...");
+            Log.Info($"Retention policy about to delete {toDelete.Length} release(s)...");
             foreach (var del in toDelete) {
                 await DeleteObject(client, del.FileName);
             }

--- a/src/Velopack.Deployment/_Repository.cs
+++ b/src/Velopack.Deployment/_Repository.cs
@@ -60,7 +60,7 @@ public abstract class DownRepository<TDown> : IRepositoryCanDownload<TDown>
         VelopackAssetFeed feed = await RetryAsyncRet(() => GetReleasesAsync(options), $"Fetching releases for channel {options.Channel}...");
         var releases = feed.Assets;
 
-        Log.Info($"Found {releases.Length} release in remote file");
+        Log.Info($"Found {releases.Length} release(s) in remote file");
 
         var latest = releases.Where(r => r.Type == VelopackAssetType.Full).OrderByDescending(r => r.Version).FirstOrDefault();
         if (latest == null) {

--- a/src/Velopack.Packaging.Windows/CodeSign.cs
+++ b/src/Velopack.Packaging.Windows/CodeSign.cs
@@ -73,7 +73,7 @@ public class CodeSign
 
         if (filePaths.Length != pendingSign.Count) {
             var diff = filePaths.Length - pendingSign.Count;
-            Log.Info($"{pendingSign.Count} files will be signed, {diff} will be skipped.");
+            Log.Info($"{pendingSign.Count} file(s) will be signed, {diff} will be skipped.");
         }
 
         do {

--- a/src/Velopack.Packaging/ReleaseEntryHelper.cs
+++ b/src/Velopack.Packaging/ReleaseEntryHelper.cs
@@ -96,7 +96,7 @@ public class ReleaseEntryHelper
         foreach (var kvp in releases) {
             var exclude = kvp.Value.Where(x => x.Version.ReleaseLabels.Any(r => r.Contains('.')) || x.Version.HasMetadata).ToArray();
             if (exclude.Any()) {
-                log.Warn($"Excluding {exclude.Length} assets from legacy RELEASES file, because they " +
+                log.Warn($"Excluding {exclude.Length} asset(s) from legacy RELEASES file, because they " +
                     $"contain an invalid character in the version: {string.Join(", ", exclude.Select(x => x.FileName))}");
             }
 

--- a/src/Velopack/Sources/SimpleWebSource.cs
+++ b/src/Velopack/Sources/SimpleWebSource.cs
@@ -34,7 +34,8 @@ namespace Velopack.Sources
         /// <inheritdoc />
         public async Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
         {
-            var uri = Utility.AppendPathToUri(BaseUri, Utility.GetVeloReleaseIndexName(channel));
+            var releaseFilename = Utility.GetVeloReleaseIndexName(channel);
+            var uri = Utility.AppendPathToUri(BaseUri, releaseFilename);
             var args = new Dictionary<string, string>();
 
             if (VelopackRuntimeInfo.SystemArch != RuntimeCpu.Unknown) {
@@ -53,7 +54,7 @@ namespace Velopack.Sources
 
             var uriAndQuery = Utility.AddQueryParamsToUri(uri, args);
 
-            logger.Info($"Downloading RELEASES from '{uriAndQuery}'.");
+            logger.Info($"Downloading release file '{releaseFilename}' from '{uriAndQuery}'.");
 
             var json = await Downloader.DownloadString(uriAndQuery.ToString()).ConfigureAwait(false);
             return VelopackAssetFeed.FromJson(json);

--- a/src/Velopack/UpdateManager.cs
+++ b/src/Velopack/UpdateManager.cs
@@ -178,7 +178,7 @@ namespace Velopack
             SemanticVersion deltaFromVer = latestLocalFull.Version;
 
             var deltas = feed.Where(r => r.Type == VelopackAssetType.Delta && r.Version > deltaFromVer && r.Version <= latestRemoteFull.Version).ToArray();
-            Log.Debug($"Found {deltas.Length} delta releases between {deltaFromVer} and {latestRemoteFull.Version}.");
+            Log.Debug($"Found {deltas.Length} delta release(s) between {deltaFromVer} and {latestRemoteFull.Version}.");
             return new UpdateInfo(latestRemoteFull, false, latestLocalFull, deltas);
         }
 

--- a/test/Velopack.Tests/UtilityTests.cs
+++ b/test/Velopack.Tests/UtilityTests.cs
@@ -132,7 +132,7 @@ public class UtilityTests
 
             var count = files.Count();
 
-            logger.Info($"Created {count} files under directory {tempDir}");
+            logger.Info($"Created {count} file(s) under directory {tempDir}");
 
             var sw = new Stopwatch();
             sw.Start();


### PR DESCRIPTION
…parenthetical plurals when referring to countable file(s), release(s), asset(s), etc.

Closes #90.