### PR TITLE
FIx downloading of files from absolute or relative paths

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -26,12 +26,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <Target Name="AddNugetStaticFiles" BeforeTargets="Build">
-    <ItemGroup Condition=" '$(VelopackPackageId)' != '' ">
-      <None Include="..\..\artwork\Velopack_200.png" Pack="true" PackagePath="\" />
-      <None Include="..\..\README_NUGET.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
-  </Target>
+  <ItemGroup Condition=" '$(VelopackPackageId)' != '' ">
+    <None Include="..\..\artwork\Velopack_200.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README_NUGET.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <Target Name="AddNugetVendorLibs" BeforeTargets="Build" Condition=" '$(VelopackPackageVendorLibs)' == 'true' ">
     <ItemGroup>

--- a/src/Velopack/Internal/Utility.cs
+++ b/src/Velopack/Internal/Utility.cs
@@ -264,6 +264,28 @@ namespace Velopack
                 }));
         }
 
+        /// <summary>
+        /// Escapes file name such that the file name is safe for writing to disk in the packages folder
+        /// </summary>
+        public static string GetSafeFilename(string fileName)
+        {
+            string safeFileName = Path.GetFileName(fileName);
+            char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
+
+            if (safeFileName.IndexOfAny(invalidFileNameChars) != -1) {
+                StringBuilder safeName = new();
+                foreach (char ch in safeFileName) {
+                    if (Array.IndexOf(invalidFileNameChars, ch) == -1)
+                        safeName.Append(ch);
+                    else
+                        safeName.Append('_');
+                }
+                safeFileName = safeName.ToString();
+            }
+
+            return safeFileName;
+        }
+
         public static string GetDefaultTempBaseDirectory()
         {
             string tempDir;

--- a/src/Velopack/Sources/VelopackFlowUpdateSource.cs
+++ b/src/Velopack/Sources/VelopackFlowUpdateSource.cs
@@ -84,6 +84,6 @@ namespace Velopack.Sources
 
     internal record VelopackFlowReleaseAsset : VelopackAsset
     {
-        public string? Id { get; init; }
+        public string? Id { get; set; }
     }
 }

--- a/src/Velopack/UpdateManager.cs
+++ b/src/Velopack/UpdateManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -232,7 +231,7 @@ namespace Velopack
             var appTempDir = Locator.AppTempDir!;
             var appPackageDir = Locator.PackagesDir!;
 
-            var completeFile = Path.Combine(appPackageDir, GetSafeFilename(targetRelease.FileName));
+            var completeFile = Path.Combine(appPackageDir, Utility.GetSafeFilename(targetRelease.FileName));
             var incompleteFile = completeFile + ".partial";
 
             try {
@@ -261,7 +260,7 @@ namespace Velopack
                                     $"Only full update will be available.");
                             } else {
                                 using var _1 = Utility.GetTempDirectory(out var deltaStagingDir, appTempDir);
-                                string basePackagePath = Path.Combine(appPackageDir, GetSafeFilename(updates.BaseRelease.FileName));
+                                string basePackagePath = Path.Combine(appPackageDir, Utility.GetSafeFilename(updates.BaseRelease.FileName));
                                 if (!File.Exists(basePackagePath))
                                     throw new Exception($"Unable to find base package {basePackagePath} for delta update.");
                                 EasyZip.ExtractZipToDirectory(Log, basePackagePath, deltaStagingDir);
@@ -318,27 +317,6 @@ namespace Velopack
                 }
 
                 CleanPackagesExcept(completeFile);
-            }
-
-
-            // Ensures that the file name is safe for writing to disk without escaping the packages folder
-            static string GetSafeFilename(string fileName)
-            {
-                string safeFileName = Path.GetFileName(fileName);
-                char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
-
-                if (safeFileName.IndexOfAny(invalidFileNameChars) != -1 ) {
-                    StringBuilder safeName = new();
-                    foreach(char ch in safeFileName) { 
-                        if (Array.IndexOf(invalidFileNameChars, ch) == -1)
-                            safeName.Append(ch);
-                        else
-                            safeName.Append('_');
-                    }
-                    safeFileName = safeName.ToString();
-                }
-
-                return safeFileName;
             }
         }
 

--- a/src/Velopack/UpdateManager.cs
+++ b/src/Velopack/UpdateManager.cs
@@ -231,7 +231,7 @@ namespace Velopack
             var appTempDir = Locator.AppTempDir!;
             var appPackageDir = Locator.PackagesDir!;
 
-            var completeFile = Path.Combine(appPackageDir, targetRelease.FileName);
+            var completeFile = Path.Combine(appPackageDir, Path.GetFileName(targetRelease.FileName));
             var incompleteFile = completeFile + ".partial";
 
             try {
@@ -260,7 +260,7 @@ namespace Velopack
                                     $"Only full update will be available.");
                             } else {
                                 using var _1 = Utility.GetTempDirectory(out var deltaStagingDir, appTempDir);
-                                string basePackagePath = Path.Combine(appPackageDir, updates.BaseRelease.FileName);
+                                string basePackagePath = Path.Combine(appPackageDir, Path.GetFileName(updates.BaseRelease.FileName));
                                 if (!File.Exists(basePackagePath))
                                     throw new Exception($"Unable to find base package {basePackagePath} for delta update.");
                                 EasyZip.ExtractZipToDirectory(Log, basePackagePath, deltaStagingDir);

--- a/src/Velopack/UpdateManager.cs
+++ b/src/Velopack/UpdateManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -231,7 +232,7 @@ namespace Velopack
             var appTempDir = Locator.AppTempDir!;
             var appPackageDir = Locator.PackagesDir!;
 
-            var completeFile = Path.Combine(appPackageDir, Path.GetFileName(targetRelease.FileName));
+            var completeFile = Path.Combine(appPackageDir, GetSafeFilename(targetRelease.FileName));
             var incompleteFile = completeFile + ".partial";
 
             try {
@@ -260,7 +261,7 @@ namespace Velopack
                                     $"Only full update will be available.");
                             } else {
                                 using var _1 = Utility.GetTempDirectory(out var deltaStagingDir, appTempDir);
-                                string basePackagePath = Path.Combine(appPackageDir, Path.GetFileName(updates.BaseRelease.FileName));
+                                string basePackagePath = Path.Combine(appPackageDir, GetSafeFilename(updates.BaseRelease.FileName));
                                 if (!File.Exists(basePackagePath))
                                     throw new Exception($"Unable to find base package {basePackagePath} for delta update.");
                                 EasyZip.ExtractZipToDirectory(Log, basePackagePath, deltaStagingDir);
@@ -317,6 +318,27 @@ namespace Velopack
                 }
 
                 CleanPackagesExcept(completeFile);
+            }
+
+
+            // Ensures that the file name is safe for writing to disk without escaping the packages folder
+            static string GetSafeFilename(string fileName)
+            {
+                string safeFileName = Path.GetFileName(fileName);
+                char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
+
+                if (safeFileName.IndexOfAny(invalidFileNameChars) != -1 ) {
+                    StringBuilder safeName = new();
+                    foreach(char ch in safeFileName) { 
+                        if (Array.IndexOf(invalidFileNameChars, ch) == -1)
+                            safeName.Append(ch);
+                        else
+                            safeName.Append('_');
+                    }
+                    safeFileName = safeName.ToString();
+                }
+
+                return safeFileName;
             }
         }
 


### PR DESCRIPTION
*Long story*
I saw that SimpleWebSource seems to support specifying absolute url's in the "Filename" path of releases.json so I did try a scenaro with "releases.json" from one website and the .nupkg files from another location only to get download problems because the UpdateManager tried to create a file named "https://my.domain/client/mypackage." which contains invalid filename characters.

I suppose you can get the similar problems if you make the path relative (I assume "../../filename" fill put the downloaded file in the completely wrong folder .

I've made the quickest possible fix and only uses the filename part when choosing what the temporary downloaded file should be called (and verified that the update works as expected).
