### PR TITLE
DisablePayloadSigning in S3 deployment

### DIFF
--- a/src/Velopack.Deployment/S3Repository.cs
+++ b/src/Velopack.Deployment/S3Repository.cs
@@ -154,6 +154,10 @@ public class S3Repository : ObjectRepository<S3DownloadOptions, S3UploadOptions,
             BucketName = bucket,
             FilePath = f.FullName,
             Key = key,
+            //due to compatibility reasons CloudFlare R2, Oracle Object storage (maybe some other providers)
+            // doesn't support Streaming SigV4 which is used in chunked uploading
+            DisablePayloadSigning = true,
+            DisableDefaultChecksumValidation = false,
         };
 
         if (noCache) {


### PR DESCRIPTION
DisablePayloadSigning = true and DisableDefaultChecksumValidation = false to greater compatibility with S3 priverders
. Oracle/Cloudflare doesn't support Streaming SigV4 which is used in [chunked uploading](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html) as decribed in https://kian.org.uk/cloudflare-r2-and-aws-sdk-for-net/.
theoretically we can try upload and if fails use this new apporach but exception occurs AFTER upload. And due to my reaearch this cannot be easly checked upfront..

