### PR TITLE
Add generic Json enum converter for AoT

### DIFF
--- a/src/Velopack/Internal/SimpleJson.cs
+++ b/src/Velopack/Internal/SimpleJson.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NuGet.Versioning;
 
 #if NET5_0_OR_GREATER
@@ -31,7 +31,13 @@ namespace Velopack.Json
             PropertyNameCaseInsensitive = true,
             WriteIndented = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter(), new SemanticVersionConverter() },
+            Converters = {
+#if NET8_0_OR_GREATER
+                new JsonStringEnumConverter<VelopackAssetType>(),
+#endif
+                new JsonStringEnumConverter(),
+                new SemanticVersionConverter()
+            },
         };
 
         public static T? DeserializeObject<T>(string json)


### PR DESCRIPTION
Related to https://github.com/velopack/velopack/issues/122

In an Avalonia app targeting .NET AoT, the following call:

```cs
var updateInfo = await updateManager.CheckForUpdatesAsync();
```
Raises the exception:
> Error checking for update.System.NotSupportedException: 'System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1[Velopack.VelopackAssetType]' is missing native code or metadata. This can happen for code that is not compatible with trimming or AOT. Inspect and fix trimming and AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility at System.Reflection.Runtime.General.TypeUnifier.WithVerifiedTypeHandle(RuntimeConstructedGenericTypeInfo, RuntimeTypeInfo[]) + 0x75

I've added the generic `JsonStringEnumConverter<VelopackAssetType>` to the `Converters` collection in the `SimpleJson` class. This appears to resolve the issue.
