### PR TITLE
Add POC sample for signing of releases.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -506,3 +506,4 @@ tests/Test.xml
 
 
 launchsettings.json
+/samples/Signing/keys/rsa.pem

--- a/.gitignore
+++ b/.gitignore
@@ -506,4 +506,5 @@ tests/Test.xml
 
 
 launchsettings.json
-/samples/Signing/keys/rsa.pem
+/samples/Signing/keys/*.pem
+/samples/Signing/keys/*.xml

--- a/Velopack.sln
+++ b/Velopack.sln
@@ -58,6 +58,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Velopack.Build", "src\Velop
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Velopack.IcoLib", "src\Velopack.IcoLib\Velopack.IcoLib.csproj", "{8A0A980A-D51C-458E-8942-00BC900FD2D0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Signing", "Signing", "{A6F90676-D296-47BB-955B-BCB5EEACF214}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReleaseSigner", "samples\Signing\ReleaseSigner\ReleaseSigner.csproj", "{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "keys", "keys", "{AF744AB4-8CEA-463F-B36D-99587BEA6426}"
+	ProjectSection(SolutionItems) = preProject
+		samples\Signing\ReleaseSigner\rsa.pem = samples\Signing\ReleaseSigner\rsa.pem
+		samples\Signing\ReleaseSigner\rsa.public.pem = samples\Signing\ReleaseSigner\rsa.public.pem
+		samples\Signing\ReleaseSigner\rsa.public.xml = samples\Signing\ReleaseSigner\rsa.public.xml
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SigningSample", "samples\Signing\SigningSample\SigningSample.csproj", "{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -128,6 +141,14 @@ Global
 		{8A0A980A-D51C-458E-8942-00BC900FD2D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A0A980A-D51C-458E-8942-00BC900FD2D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A0A980A-D51C-458E-8942-00BC900FD2D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +162,10 @@ Global
 		{8B27C4BF-21B8-48B0-80F8-74520227C35F} = {7AC3A776-B582-4B65-9D03-BD52332B5CA3}
 		{9E0F2B00-1B88-4B75-BEED-6DF8DBCA36B5} = {3EBFA551-780C-473D-A197-0EE56F2CBA82}
 		{5ED2E9AF-101D-4D2D-B0B5-90A920EF692D} = {7AC3A776-B582-4B65-9D03-BD52332B5CA3}
+		{A6F90676-D296-47BB-955B-BCB5EEACF214} = {3EBFA551-780C-473D-A197-0EE56F2CBA82}
+		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
+		{AF744AB4-8CEA-463F-B36D-99587BEA6426} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
+		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {68CA987A-9BAB-4C75-8EEB-4596BA6BBD07}

--- a/Velopack.sln
+++ b/Velopack.sln
@@ -62,13 +62,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Signing", "Signing", "{A6F9
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReleaseSigner", "samples\Signing\ReleaseSigner\ReleaseSigner.csproj", "{DDDBBC67-0E95-4FD6-B2BD-102507302FC6}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "keys", "keys", "{AF744AB4-8CEA-463F-B36D-99587BEA6426}"
-	ProjectSection(SolutionItems) = preProject
-		samples\Signing\ReleaseSigner\rsa.pem = samples\Signing\ReleaseSigner\rsa.pem
-		samples\Signing\ReleaseSigner\rsa.public.pem = samples\Signing\ReleaseSigner\rsa.public.pem
-		samples\Signing\ReleaseSigner\rsa.public.xml = samples\Signing\ReleaseSigner\rsa.public.xml
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SigningSample", "samples\Signing\SigningSample\SigningSample.csproj", "{3EE56FBD-784F-4B22-888A-0B0EA5215AF1}"
 EndProject
 Global
@@ -164,7 +157,6 @@ Global
 		{5ED2E9AF-101D-4D2D-B0B5-90A920EF692D} = {7AC3A776-B582-4B65-9D03-BD52332B5CA3}
 		{A6F90676-D296-47BB-955B-BCB5EEACF214} = {3EBFA551-780C-473D-A197-0EE56F2CBA82}
 		{DDDBBC67-0E95-4FD6-B2BD-102507302FC6} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
-		{AF744AB4-8CEA-463F-B36D-99587BEA6426} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
 		{3EE56FBD-784F-4B22-888A-0B0EA5215AF1} = {A6F90676-D296-47BB-955B-BCB5EEACF214}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -10,12 +10,12 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>VelopackSampleReleaseDir</_Parameter1>
-      <_Parameter2>$(MSBuildThisFileDirectory)$(ProjectName)/releases</_Parameter2>
+      <_Parameter2>$(MSBuildProjectDirectory)/releases</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\SampleHelper.cs" Link="SampleHelper.cs" Visible="false" />
+    <Compile Include="$(MSBuildThisFileDirectory)/SampleHelper.cs" Link="SampleHelper.cs" Visible="false" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(UseLocalVelopack) != ''">

--- a/samples/Signing/ReleaseSigner/Program.cs
+++ b/samples/Signing/ReleaseSigner/Program.cs
@@ -1,0 +1,132 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using ConsoleAppFramework;
+using SigningSample;
+
+var app = ConsoleApp.Create();
+
+app.Add("generate rsa", ([Argument] int keySize = 2048) =>
+{
+	var rsa = RSA.Create(keySize);
+
+	File.WriteAllText("rsa.pem", rsa.ExportRSAPrivateKeyPem());
+	File.WriteAllText("rsa.public.pem", rsa.ExportRSAPublicKeyPem());
+	// NET FRAMEWORK only support XML, and web installer runs on .NET FRAMEWORK
+	File.WriteAllText("rsa.public.xml", rsa.ToXmlString(includePrivateParameters: false));
+});
+
+app.Add("export keyvault", ExportKeyVaultKey);
+
+app.Add("sign rsa", ([Argument] string releaseFile, string rsaFile = "rsa.pem") =>
+{
+	Console.WriteLine("Create RSA");
+	using var rsa = RSACryptoServiceProvider.Create();
+	Console.WriteLine("Loading RSA");
+	rsa.ImportFromPem(File.ReadAllText(rsaFile));
+
+	AddSignature(releaseFile, rsa);
+});
+
+app.Add("sign keyvault", AddSignatureUsingKeyVault);
+
+app.Add("verify rsa", ([Argument] string releaseFile, string rsaFile = "rsa.public.pem") =>
+{
+	Console.WriteLine("Create RSA");
+	var rsa = RSACryptoServiceProvider.Create();
+	Console.WriteLine("Loading RSA");
+	rsa.ImportFromPem(File.ReadAllText(rsaFile));
+
+	VerifySignature(releaseFile, rsa);
+});
+
+app.Add("verify keyvault", VerifySignatureUsingKeyVault);
+
+app.Run(args);
+return;
+
+/// <summary>
+/// Signs the release file using keys from keyvault
+/// </summary>
+/// <param name="releaseFile">path to releases.win.json</param>
+/// <param name="keyVaultUri">KeyVault uri</param>
+/// <param name="keyVaultKey">name of key in KeyVault</param>
+static void AddSignatureUsingKeyVault([Argument] string releaseFile, string keyVaultUri, string keyVaultKey)
+{
+	using RSA key = GetKeyVaultKey(keyVaultUri, keyVaultKey);
+
+	AddSignature(releaseFile, key);
+}
+
+static void AddSignature(string releaseFile, RSA key)
+{
+	// Read release file
+	string releaseContents = File.ReadAllText(releaseFile, Encoding.UTF8);
+
+	releaseContents = VelopackSignatureHelper.AddSignature(releaseContents, key);
+
+	File.WriteAllText(releaseFile, releaseContents, Encoding.UTF8);
+    Console.WriteLine("Signature added");
+}
+
+/// <summary>
+/// Verifies the signature of a release file using a key from Azure Key Vault.
+/// </summary>
+/// <param name="releaseFile">The path to the release file.</param>
+/// <param name="keyVaultUri">The URI of the Azure Key Vault.</param>
+/// <param name="keyVaultKey">The name of the key in Azure Key Vault.</param>
+static void VerifySignatureUsingKeyVault([Argument] string releaseFile, string keyVaultUri, string keyVaultKey)
+{
+	using RSA key = GetKeyVaultKey(keyVaultUri, keyVaultKey);
+
+	VerifySignature(releaseFile, key);
+}
+
+static bool VerifySignature(string releaseFile, RSA key)
+{
+	// Read release file
+	var releaseContents = File.ReadAllText(releaseFile, Encoding.UTF8).AsSpan();
+
+	if (VelopackSignatureHelper.VerifySignature(releaseContents, key))
+	{
+		Console.WriteLine("Validation OK");
+		return true;
+	}
+	else
+	{
+		Console.WriteLine("Validation FAILED");
+		return false;
+	}
+}
+
+/// <summary>
+/// Exports the public RSA key from Azure Key Vault to a specified file.
+/// </summary>
+/// <param name="keyVaultUri">The URI of the Azure Key Vault.</param>
+/// <param name="keyVaultKey">The name of the key in Azure Key Vault.</param>
+/// <param name="rsaFile">The file path where the exported RSA public key will be saved. Defaults to "rsa.public.pem".</param>
+static void ExportKeyVaultKey(string keyVaultUri, string keyVaultKey, string rsaFile = "rsa.public.pem")
+{
+	using RSA rsa = GetKeyVaultKey(keyVaultUri, keyVaultKey);
+
+	switch (rsa)
+	{
+		case RSAKeyVault rsaKeyVault:
+			File.WriteAllText(rsaFile, rsaKeyVault.ExportRSAPublicKeyPem());
+			File.WriteAllText("rsa.public.xml", rsaKeyVault.ToXmlString(includePrivateParameters: false));
+			break;
+		default:
+			throw new InvalidOperationException("Key is not RSA");
+	}
+}
+
+static RSAKeyVault GetKeyVaultKey(string keyVaultUri, string keyVaultKey)
+{
+	KeyClient keyVault = new KeyClient(new Uri(keyVaultUri), new DefaultAzureCredential());
+	CryptographyClient client = keyVault.GetCryptographyClient(keyVaultKey);
+	RSAKeyVault rsa = client.CreateRSA();
+	return rsa;
+}
+

--- a/samples/Signing/ReleaseSigner/README.md
+++ b/samples/Signing/ReleaseSigner/README.md
@@ -1,0 +1,56 @@
+﻿# Release Signer
+This is a small helper program to sign the `release.win.json` file created by Velopack.
+
+## Usage
+
+```
+> .\ReleaseSigner.exe --help
+
+Usage: [command] [-h|--help] [--version]
+
+Commands:
+  export keyvault    Exports the public RSA key from Azure Key Vault to a specified file.
+  generate rsa
+  sign keyvault      Signs the release file using keys from keyvault
+  sign rsa
+  verify keyvault    Verifies the signature of a release file using a key from Azure Key Vault.
+  verify rsa
+
+```
+
+##  Examples
+
+### Local RSA Keys
+```
+
+# To generate new keys (public and private)
+.\ReleaseSigner.exe generate rsa 
+
+# To sign the release.win.json file run
+.\ReleaseSigner.exe sign rsa release.win.json
+
+# To verify the signed file run
+.\ReleaseSigner.exe verify rsa release.win.json
+
+```
+
+### Azure keyvault
+```
+
+# To export public key to local file run
+.\ReleaseSigner.exe --key-vault-uri https://KEYVAULT.vault.azure.net/ --key-vault-key VelopackReleases
+
+# To sign the release.win.json file run
+.\ReleaseSigner.exe sign keyvault release.win.json --key-vault-uri https://KEYVAULT.vault.azure.net/ --key-vault-key VelopackReleases
+
+# To verify the signed file run
+.\ReleaseSigner.exe verify keyvault release.win.json --key-vault-uri https://KEYVAULT.vault.azure.net/ --key-vault-key VelopackReleases
+
+```
+
+## Key rotation
+
+1. Create a new key
+2. Export public part of keys and make sure that the application supports **both old and new key**
+3. Ensure new app has rolled out to all users
+4. Make sure installers are updated and start using the new key 

--- a/samples/Signing/ReleaseSigner/ReleaseSigner.csproj
+++ b/samples/Signing/ReleaseSigner/ReleaseSigner.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Include="ConsoleAppFramework" Version="5.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/samples/Signing/ReleaseSigner/VelopackSignatureHelper.cs
+++ b/samples/Signing/ReleaseSigner/VelopackSignatureHelper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SigningSample;
+
+internal static class VelopackSignatureHelper
+{
+	public const string SignatureAttribute = "Signature";
+
+	public static bool VerifySignature(ReadOnlySpan<char> releaseContents, RSA key)
+	{
+		string expectedStart = $@"{{ ""Version"": 1, ""{SignatureAttribute}"": """;
+		if (!releaseContents.StartsWith(expectedStart.AsSpan(), StringComparison.Ordinal))
+			throw new CryptographicException("Release file was not signed");
+
+		int hashEnd = releaseContents.Slice(expectedStart.Length).IndexOf('"');
+		if (hashEnd < 0)
+			throw new CryptographicException("Release file was not signed");
+
+		string signature = releaseContents.Slice(expectedStart.Length, hashEnd).ToString();
+		string jsonWithoutHash = string.Concat("{", releaseContents.Slice(expectedStart.Length + hashEnd + 3).ToString());
+
+		byte[] data = GetCanonicalDataForHashing(jsonWithoutHash);
+		return key.VerifyData(data, Convert.FromBase64String(signature), HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+	}
+
+	public static string AddSignature(string releaseContents, RSA key)
+	{
+		if (releaseContents.Contains(SignatureAttribute))
+			throw new InvalidOperationException("Release file already signed");
+
+		byte[] data = GetCanonicalDataForHashing(releaseContents);
+		byte[] signed = key.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+
+		string signatureString = Convert.ToBase64String(signed);
+
+		string jsonStart = $" \"Version\": 1, \"{SignatureAttribute}\": \"{signatureString}\",\n";
+		return releaseContents.Insert(1, jsonStart);
+	}
+
+	/// <summary>
+	/// Convert json to "canonical form" so that data
+	/// is the same even if newline char changes and return a byte array that can be used for hashing
+	/// </summary>
+	/// <remarks>
+	/// We could strip leading whitespace or other nonsignificant whitespace, or similar which does not affect the JSON data.
+	/// But the file should not be modified anyway, and we don't want to risk any flaw that would allow an attacker
+	/// to change the file without the signature detecting it.
+	/// </remarks>
+	static byte[] GetCanonicalDataForHashing(string releaseContents)
+	{
+		// 1. Change line endings from windows to Linux
+		releaseContents = releaseContents.Replace("\r\n", "\n");
+
+		return Encoding.UTF8.GetBytes(releaseContents);
+	}
+}

--- a/samples/Signing/SigningSample/App.xaml
+++ b/samples/Signing/SigningSample/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="VeloWpfSample.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:VeloWpfSample"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/samples/Signing/SigningSample/App.xaml.cs
+++ b/samples/Signing/SigningSample/App.xaml.cs
@@ -1,0 +1,8 @@
+﻿using System.Windows;
+
+namespace VeloWpfSample
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/samples/Signing/SigningSample/AssemblyInfo.cs
+++ b/samples/Signing/SigningSample/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,
+    ResourceDictionaryLocation.SourceAssembly
+)]

--- a/samples/Signing/SigningSample/LocalDirectoryDownloader.cs
+++ b/samples/Signing/SigningSample/LocalDirectoryDownloader.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using Velopack.Sources;
+
+namespace VeloWpfSample
+{
+    class LocalDirectoryDownloader : IFileDownloader
+    {
+        private string _basePath;
+
+        public LocalDirectoryDownloader(string basePath)
+        {
+            _basePath = basePath;
+        }
+
+        public Task<byte[]> DownloadBytes(string url, string authorization = null, string accept = null)
+        {
+            return File.ReadAllBytesAsync(GetFilePath(url));
+        }
+
+        public Task DownloadFile(string url, string targetFile, Action<int> progress, string authorization = null, string accept = null, CancellationToken cancelToken = default)
+        {
+            File.Copy(GetFilePath(url), targetFile);
+            return Task.CompletedTask;
+        }
+
+        public Task<string> DownloadString(string url, string authorization = null, string accept = null)
+        {
+            return File.ReadAllTextAsync(GetFilePath(url));
+        }
+
+        string GetFilePath(string url)
+        {
+            return Path.Combine(_basePath, new Uri(url).LocalPath.TrimStart('/'));
+        }
+    }
+}

--- a/samples/Signing/SigningSample/MainWindow.xaml
+++ b/samples/Signing/SigningSample/MainWindow.xaml
@@ -1,0 +1,28 @@
+﻿<Window x:Class="VeloWpfSample.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:VeloWpfSample"
+        mc:Ignorable="d"
+        WindowStartupLocation="CenterScreen"
+        Title="VeloWpfSample" Height="600" Width="600">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="15" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <TextBlock Margin="10" Name="TextStatus" />
+            <StackPanel Orientation="Horizontal" Margin="10">
+                <Button Name="BtnCheckUpdate" Content="Check for Updates" Click="BtnCheckUpdateClick" Padding="10,5" />
+                <Button Margin="10,0" Name="BtnDownloadUpdate" Content="Download" Click="BtnDownloadUpdateClick" Padding="10,5" IsEnabled="False" />
+                <Button Name="BtnRestartApply" Content="Restart &amp; Apply" Click="BtnRestartApplyClick" Padding="10,5" IsEnabled="False" />
+            </StackPanel>
+        </StackPanel>
+        <ScrollViewer Name="ScrollLog" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
+            <TextBlock Name="TextLog" Background="DarkGoldenrod" Foreground="White" TextWrapping="Wrap" />
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/samples/Signing/SigningSample/MainWindow.xaml.cs
+++ b/samples/Signing/SigningSample/MainWindow.xaml.cs
@@ -1,0 +1,115 @@
+﻿using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Windows;
+using Microsoft.Extensions.Logging;
+using SigningSample;
+using Velopack;
+using Velopack.Sources;
+
+namespace VeloWpfSample
+{
+    public partial class MainWindow : Window
+    {
+        private UpdateManager _um;
+        private UpdateInfo _update;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            string updateUrl = SampleHelper.GetReleasesDir(); // replace with your update url
+
+            // Load signing keys
+            var signingKey = RSA.Create();
+            signingKey.ImportFromPem(File.ReadAllText(@"keys\rsa.public.pem"));
+            var signedDownloader = new SignedDownloader(signingKey, new LocalDirectoryDownloader(updateUrl), Program.Log);
+            var updateSource = new SimpleWebSource("http://dummy", signedDownloader);
+
+            _um = new UpdateManager(updateSource, logger: Program.Log);
+
+            TextLog.Text = Program.Log.ToString();
+            Program.Log.LogUpdated += LogUpdated;
+            UpdateStatus();
+        }
+
+        private async void BtnCheckUpdateClick(object sender, RoutedEventArgs e)
+        {
+            Working();
+            try {
+                // ConfigureAwait(true) so that UpdateStatus() is called on the UI thread
+                _update = await _um.CheckForUpdatesAsync().ConfigureAwait(true);
+            } catch (Exception ex) {
+                Program.Log.LogError(ex, "Error checking for updates");
+            }
+            UpdateStatus();
+        }
+
+        private async void BtnDownloadUpdateClick(object sender, RoutedEventArgs e)
+        {
+            Working();
+            try {
+                // ConfigureAwait(true) so that UpdateStatus() is called on the UI thread
+                await _um.DownloadUpdatesAsync(_update, Progress).ConfigureAwait(true);
+            } catch (Exception ex) {
+                Program.Log.LogError(ex, "Error downloading updates");
+            }
+            UpdateStatus();
+        }
+
+        private void BtnRestartApplyClick(object sender, RoutedEventArgs e)
+        {
+            _um.ApplyUpdatesAndRestart(_update);
+        }
+
+        private void LogUpdated(object sender, LogUpdatedEventArgs e)
+        {
+            // logs can be sent from other threads
+            this.Dispatcher.InvokeAsync(() => {
+                TextLog.Text = e.Text;
+                ScrollLog.ScrollToEnd();
+            });
+        }
+
+        private void Progress(int percent)
+        {
+            // progress can be sent from other threads
+            this.Dispatcher.InvokeAsync(() => {
+                TextStatus.Text = $"Downloading ({percent}%)...";
+            });
+        }
+
+        private void Working()
+        {
+            Program.Log.LogInformation("");
+            BtnCheckUpdate.IsEnabled = false;
+            BtnDownloadUpdate.IsEnabled = false;
+            BtnRestartApply.IsEnabled = false;
+            TextStatus.Text = "Working...";
+        }
+
+        private void UpdateStatus()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"Velopack version: {VelopackRuntimeInfo.VelopackNugetVersion}");
+            sb.AppendLine($"This app version: {(_um.IsInstalled ? _um.CurrentVersion : "(n/a - not installed)")}");
+
+            if (_update != null) {
+                sb.AppendLine($"Update available: {_update.TargetFullRelease.Version}");
+                BtnDownloadUpdate.IsEnabled = true;
+            } else {
+                BtnDownloadUpdate.IsEnabled = false;
+            }
+
+            if (_um.IsUpdatePendingRestart) {
+                sb.AppendLine("Update ready, pending restart to install");
+                BtnRestartApply.IsEnabled = true;
+            } else {
+                BtnRestartApply.IsEnabled = false;
+            }
+
+            TextStatus.Text = sb.ToString();
+            BtnCheckUpdate.IsEnabled = true;
+        }
+    }
+}

--- a/samples/Signing/SigningSample/MemoryLogger.cs
+++ b/samples/Signing/SigningSample/MemoryLogger.cs
@@ -1,0 +1,44 @@
+﻿using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace SigningSample
+{
+    public class LogUpdatedEventArgs : EventArgs
+    {
+        public string Text { get; set; }
+    }
+
+    public class MemoryLogger : ILogger
+    {
+        public event EventHandler<LogUpdatedEventArgs> LogUpdated;
+        private readonly StringBuilder _sb = new StringBuilder();
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            lock (_sb) {
+                var message = formatter(state, exception);
+                if (exception != null) message += "\n" + exception.ToString();
+                Console.WriteLine("log: " + message);
+                _sb.AppendLine(message);
+                LogUpdated?.Invoke(this, new LogUpdatedEventArgs { Text = _sb.ToString() });
+            }
+        }
+
+        public override string ToString()
+        {
+            lock (_sb) {
+                return _sb.ToString();
+            }
+        }
+    }
+}

--- a/samples/Signing/SigningSample/Program.cs
+++ b/samples/Signing/SigningSample/Program.cs
@@ -1,0 +1,36 @@
+﻿using System.Windows;
+using Velopack;
+using VeloWpfSample;
+
+namespace SigningSample
+{
+    // Since WPF has an "automatic" Program.Main, we need to create our own.
+    // In order for this to work, you must also add the following to your .csproj:
+    // <StartupObject>VeloWpfSample.Program</StartupObject>
+    public class Program
+    {
+        public static MemoryLogger Log { get; private set; }
+
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            try {
+                // Logging is essential for debugging! Ideally you should write it to a file.
+                Log = new MemoryLogger();
+
+                // It's important to Run() the VelopackApp as early as possible in app startup.
+                VelopackApp.Build()
+                    .WithFirstRun((v) => { /* Your first run code here */ })
+                    .Run(Log);
+
+                // We can now launch the WPF application as normal.
+                var app = new App();
+                app.InitializeComponent();
+                app.Run();
+
+            } catch (Exception ex) {
+                MessageBox.Show("Unhandled exception: " + ex.ToString());
+            }
+        }
+    }
+}

--- a/samples/Signing/SigningSample/SignedDownloader.cs
+++ b/samples/Signing/SigningSample/SignedDownloader.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Velopack.Sources;
+
+namespace SigningSample;
+
+internal class SignedDownloader : IFileDownloader
+{
+    private RSA _publicKey;
+    private readonly IFileDownloader _fileDownloader;
+    private readonly ILogger logger;
+
+    public SignedDownloader(RSA rsaKey, IFileDownloader fileDownloader, ILogger logger)
+    {
+        _publicKey = rsaKey;
+        _fileDownloader = fileDownloader;
+        this.logger = logger;
+    }
+
+    async Task<string> IFileDownloader.DownloadString(string url, string authorization, string accept)
+    {
+        var json = await _fileDownloader.DownloadString(url, authorization, accept)
+            .ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(json)) {
+            logger.LogInformation("Verifying signature...");
+            if (!VelopackSignatureHelper.VerifySignature(json, _publicKey))
+                throw new CryptographicException("Signature verification failed");
+
+            logger.LogInformation("Signature verified");
+        }
+
+        return json;
+    }
+
+    Task IFileDownloader.DownloadFile(string url, string targetFile, Action<int> progress, string authorization, string accept, CancellationToken cancelToken)
+        => _fileDownloader.DownloadFile(url, targetFile, progress, authorization, accept, cancelToken);
+
+    Task<byte[]> IFileDownloader.DownloadBytes(string url, string authorization, string accept)
+        => _fileDownloader.DownloadBytes(url, authorization, accept);
+}

--- a/samples/Signing/SigningSample/SigningSample.csproj
+++ b/samples/Signing/SigningSample/SigningSample.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- This overrides the default Program.Main that WPF creates for you, and allows you to add VelopackApp -->
+    <StartupObject>SigningSample.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ReleaseSigner\VelopackSignatureHelper.cs" Link="VelopackSignatureHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--Condition below is only needed to test this sample project against the local projects instead of the NuGet package. Remove it in your app.-->
+    <PackageReference Include="Velopack" Version="0.*" Condition="$(UseLocalVelopack) == ''" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="keys\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\keys\rsa.public.pem" Link="keys\rsa.public.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/Signing/SigningSample/build.bat
+++ b/samples/Signing/SigningSample/build.bat
@@ -1,0 +1,22 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if "%~1"=="" (
+    echo Version number is required.
+    echo Usage: build.bat [version]
+    exit /b 1
+)
+
+set "version=%~1"
+
+echo.
+echo Compiling SigningSample with dotnet...
+dotnet publish -c Release -o %~dp0publish
+
+echo.
+echo Building Velopack Release v%version%
+vpk pack -u SigningSample -v %version% -o %~dp0releases -p %~dp0publish
+
+echo.
+echo "Signing releases.win.json, ensure you have created the keys"
+%~dp0../ReleaseSigner/bin/Release/net8.0/ReleaseSigner.exe sign rsa %~dp0releases/releases.win.json --rsa-file %~dp0../keys/rsa.pem

--- a/samples/Signing/SigningSample/readme.md
+++ b/samples/Signing/SigningSample/readme.md
@@ -1,0 +1,32 @@
+# VeloWpfSample
+_Prerequisites: vpk command line tool installed_
+
+This app demonstrates how to the releses.json can be signed and verified.
+
+Before you run this sample compile it and run the "ReleaseSigner" to generate keys
+
+```shell
+
+.\ReleaseSigner.exe generate rsa
+
+copy *.pem ..\..\keys\
+```
+
+You can run this sample by executing the build script with a version number: `build.bat 1.0.0`. Once built, you can install the app - build more updates, and then test updates and so forth. The sample app will check the local release dir for new update packages. 
+
+In your production apps, you should deploy your updates to some kind of update server instead.
+
+
+## Implementation Notes
+
+* The sample is based on the WPF Sample
+* Make sure to keep backups of keys and never commit them to source control
+* For production you might want to use some kind of secure key storage such as azure key vault
+* Only include the public key in your app, never the private key
+* Ensure you have a strategy for rotating keys (maybe even a valid backup key)
+
+
+* This sample is mostly a POC you could as well use CMS (CMSSigner to create a signature, detacted or not) and use that instead
+  *  By going with CMS you can leverate the OS certificate store and use that for trust instead of hardcoding keys
+   certificate based trustd (maybe use your code signing certificate)
+  * Hardcoded raw keys might make a good tradeoff for free / OSS software where you can't afford a code signing certificate

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -4,6 +4,8 @@
 
 - [**VeloWpfSample**](VeloWpfSample) - demonstrates how to use Velopack effectively with WPF.
 
+- [**Signing**](Signing) - demonstrates a POC of how the releases.json can be digitally signed and verified to prevent tampering of the updates.
+
 ## Other Languages
 Note that only sample apps written in C# using the core reference library are available here. 
 


### PR DESCRIPTION
This adds a simple POC of how signing and verification of release.json can be achived.

There is a small program that can generate keys and perform signing (using .pem files or azure key vault) as well as validating signatures.

A copy of the WPF sample has been added that adds a signature check. 
* Only MainWindow constructor has changed

See sample readme for more details.

Possible core API improvements:
- Add extension point for validating releases.json (or nuget.package) to make similar checks easier to write


IMPORTANT: 
- Always backup keys and ensure there is a plan to allow rotating keys
- This is mostly a POC that can be further built upon (if you have a valid code signing certificate you might want to use that instead)


Note:
- I will go on vacation now so I might be **very** slow to respond 