### PR TITLE
Remove the --appDir argument

### DIFF
--- a/src/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
+++ b/src/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
@@ -18,11 +18,11 @@ public class LinuxPackCommandRunner : PackageBuilder<LinuxPackOptions>
         var dir = TempDir.CreateSubdirectory("PreprocessPackDir.AppDir");
         var bin = dir.CreateSubdirectory("usr").CreateSubdirectory("bin");
 
-        if (Options.PackIsAppDir) {
-            Log.Info("Using provided AppDir, will skip building new one.");
+        if (Options.PackDirectory.EndsWith(".AppDir", StringComparison.OrdinalIgnoreCase)) {
+            Log.Info("Pack directory ends with .AppDir, will skip building new one.");
             CopyFiles(new DirectoryInfo(Options.PackDirectory), dir, progress, true);
         } else {
-            Log.Info("Building automatic AppDir from pack directory");
+            Log.Info("Building new AppDir from pack directory contents");
             var appRunPath = Path.Combine(dir.FullName, "AppRun");
 
             // app icon
@@ -76,7 +76,6 @@ public class LinuxPackCommandRunner : PackageBuilder<LinuxPackOptions>
         Options.TargetRuntime.Architecture = Options.TargetRuntime.HasArchitecture
             ? Options.TargetRuntime.Architecture
             : GetMachineForBinary(MainExePath);
-
 
         // velopack required files
         File.WriteAllText(Path.Combine(bin.FullName, "sq.version"), GenerateNuspecContent());

--- a/src/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
+++ b/src/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
@@ -28,8 +28,6 @@ public class LinuxPackOptions : IPackOptions
 
     public string Channel { get; set; }
 
-    public bool PackIsAppDir { get; set; }
-
     public string Exclude { get; set; }
 
     public bool NoPortable { get; set; }

--- a/src/Velopack.Vpk/Commands/LinuxPackCommand.cs
+++ b/src/Velopack.Vpk/Commands/LinuxPackCommand.cs
@@ -2,34 +2,16 @@
 
 public class LinuxPackCommand : PackCommand
 {
-    public bool PackIsAppDir { get; private set; }
-
     public string Categories { get; private set; }
 
     public LinuxPackCommand()
-        : base("pack", "Create's a Linux .AppImage bundle from a folder containing application files.")
+        : base("pack", "Create a Linux .AppImage bundle from application files.")
     {
         this.RemoveOption(NoPortableOption);
         this.RemoveOption(NoInstOption);
 
-        var categories = AddOption<string>((v) => Categories = v, "--categories")
+        AddOption<string>((v) => Categories = v, "--categories")
             .SetDescription("Categories from the freedesktop.org Desktop Menu spec")
             .SetArgumentHelpName("NAMES");
-
-        var appDir = AddOption<DirectoryInfo>((v) => {
-            var t = v.ToFullNameOrNull();
-            if (t != null) {
-                PackDirectory = t;
-                PackIsAppDir = true;
-            }
-        }, "--appDir")
-            .SetDescription("Directory containing application in .AppDir format")
-            .SetArgumentHelpName("DIR")
-            .MustNotBeEmpty();
-
-        this.AtLeastOneRequired(PackDirectoryOption, appDir);
-        this.AreMutuallyExclusive(PackDirectoryOption, appDir);
-        this.AreMutuallyExclusive(IconOption, appDir);
-        this.AreMutuallyExclusive(categories, appDir);
     }
 }

--- a/src/Velopack.Vpk/Commands/_BaseCommand.cs
+++ b/src/Velopack.Vpk/Commands/_BaseCommand.cs
@@ -16,7 +16,7 @@ public class BaseCommand : CliCommand
     {
     }
 
-    protected virtual CliOption<T> AddOption<T>(Action<T> setValue, params string[] aliases)
+    protected CliOption<T> AddOption<T>(Action<T> setValue, params string[] aliases)
     {
         return AddOption(setValue, new CliOption<T>(aliases.OrderByDescending(a => a.Length).First(), aliases));
     }
@@ -53,7 +53,7 @@ public class BaseCommand : CliCommand
         return opt;
     }
 
-    protected virtual void RemoveOption(CliOption option)
+    protected void RemoveOption(CliOption option)
     {
         _setters.Remove(option);
         _envHelp.Remove(option);
@@ -62,7 +62,7 @@ public class BaseCommand : CliCommand
 
     public string GetEnvVariableName(CliOption option) => _envHelp.ContainsKey(option) ? _envHelp[option] : null;
 
-    public virtual void SetProperties(ParseResult context, IConfiguration config, RuntimeOs targetOs)
+    public void SetProperties(ParseResult context, IConfiguration config, RuntimeOs targetOs)
     {
         TargetOs = targetOs;
         foreach (var kvp in _setters) {
@@ -70,7 +70,7 @@ public class BaseCommand : CliCommand
         }
     }
 
-    public virtual ParseResult ParseAndApply(string command, IConfiguration config = null, RuntimeOs? targetOs = null)
+    public ParseResult ParseAndApply(string command, IConfiguration config = null, RuntimeOs? targetOs = null)
     {
         var x = Parse(command);
         SetProperties(x, config ?? new ConfigurationManager(), targetOs ?? VelopackRuntimeInfo.SystemOs);

--- a/src/Velopack.Vpk/Commands/_PackCommand.cs
+++ b/src/Velopack.Vpk/Commands/_PackCommand.cs
@@ -13,7 +13,7 @@ public abstract class PackCommand : PlatformCommand
 
     protected CliOption<string> PackVersionOption { get; private set; }
 
-    public string PackDirectory { get; set; }
+    public string PackDirectory { get; private set; }
 
     protected CliOption<DirectoryInfo> PackDirectoryOption { get; private set; }
 


### PR DESCRIPTION
On Mac, you can pass your compiler output or a pre-built .app folder to --packDir, so this PR just matches that logic on Linux. If the provided folder ends in `.AppDir` it will be recognized as an appdir. Otherwise, an appdir will be built as normal.