### PR TITLE
More resilient windows update logic

### DIFF
--- a/src/Rust/src/shared/bundle.rs
+++ b/src/Rust/src/shared/bundle.rs
@@ -251,7 +251,7 @@ impl BundleInfo<'_> {
         let files = self.get_file_names()?;
         let num_files = files.len();
 
-        info!("Extracting {} app files...", num_files);
+        info!("Extracting {} app files to '{}'...", num_files, current_path.to_string_lossy());
         let re = Regex::new(r"lib[\\\/][^\\\/]*[\\\/]").unwrap();
         let stub_regex = Regex::new("_ExecutionStub.exe$").unwrap();
         let symlink_regex = Regex::new(".__symlink$").unwrap();

--- a/src/Rust/src/shared/util_common.rs
+++ b/src/Rust/src/shared/util_common.rs
@@ -41,16 +41,16 @@ where
         return Ok(res.unwrap());
     }
 
-    warn!("Retrying operation in 333ms... (error was: {:?})", res.err());
-    thread::sleep(Duration::from_millis(333));
+    warn!("Retrying operation in 1000ms... (error was: {:?})", res.err());
+    thread::sleep(Duration::from_millis(1000));
 
     let res = op();
     if res.is_ok() {
         return Ok(res.unwrap());
     }
 
-    warn!("Retrying operation in 666ms... (error was: {:?})", res.err());
-    thread::sleep(Duration::from_millis(666));
+    warn!("Retrying operation in 1000ms... (error was: {:?})", res.err());
+    thread::sleep(Duration::from_millis(1000));
 
     let res = op();
     if res.is_ok() {


### PR DESCRIPTION
The "Access denied" errors when performing updates have been occurring for users - sometimes because of user error, but possibly sometimes due to transient errors like AV involvement etc. 

This PR completely re-writes the windows update logic. We will still try a fast rename, but if that fails we will fall back to robocopy instead which can work in a variety of new circumstances (such as a non-vital file being locked, or a cmd.exe running in the current directory)

Closes #159 