### PR TITLE
Fixed default channel when using cross-compile directive

### DIFF
--- a/src/Velopack.Vpk/Commands/LinuxPackCommand.cs
+++ b/src/Velopack.Vpk/Commands/LinuxPackCommand.cs
@@ -5,7 +5,7 @@ public class LinuxPackCommand : PackCommand
     public string Categories { get; private set; }
 
     public LinuxPackCommand()
-        : base("pack", "Create a Linux .AppImage bundle from application files.")
+        : base("pack", "Create a Linux .AppImage bundle from application files.", RuntimeOs.Linux)
     {
         this.RemoveOption(NoPortableOption);
         this.RemoveOption(NoInstOption);

--- a/src/Velopack.Vpk/Commands/OsxBundleCommand.cs
+++ b/src/Velopack.Vpk/Commands/OsxBundleCommand.cs
@@ -16,7 +16,7 @@ public class OsxBundleCommand : PackCommand
     }
 
     public OsxBundleCommand(string name, string description)
-        : base(name, description)
+        : base(name, description, RuntimeOs.OSX)
     {
         IconOption.RequiresExtension(".icns");
 

--- a/src/Velopack.Vpk/Commands/WindowsPackCommand.cs
+++ b/src/Velopack.Vpk/Commands/WindowsPackCommand.cs
@@ -19,7 +19,7 @@ public class WindowsPackCommand : PackCommand
     public string Shortcuts { get; private set; }
 
     public WindowsPackCommand()
-        : base("pack", "Creates a release from a folder containing application files.")
+        : base("pack", "Creates a release from a folder containing application files.", RuntimeOs.Windows)
     {
         EntryExecutableNameOption.RequiresExtension(".exe");
         IconOption.RequiresExtension(".ico");

--- a/src/Velopack.Vpk/Commands/_OutputCommand.cs
+++ b/src/Velopack.Vpk/Commands/_OutputCommand.cs
@@ -12,7 +12,7 @@ public abstract class OutputCommand : BaseCommand
 
     protected CliOption<string> ChannelOption { get; private set; }
 
-    protected OutputCommand(string name, string description)
+    protected OutputCommand(string name, string description, RuntimeOs targetOs = RuntimeOs.Unknown)
         : base(name, description)
     {
         ReleaseDirectoryOption = AddOption<DirectoryInfo>((v) => ReleaseDir = v.ToFullNameOrNull(), "-o", "--outputDir")
@@ -24,7 +24,7 @@ public abstract class OutputCommand : BaseCommand
             .SetDescription("The channel to use for this release.")
             .RequiresValidNuGetId()
             .SetArgumentHelpName("NAME")
-            .SetDefault(ReleaseEntryHelper.GetDefaultChannel(VelopackRuntimeInfo.SystemOs));
+            .SetDefault(ReleaseEntryHelper.GetDefaultChannel(targetOs == RuntimeOs.Unknown ? VelopackRuntimeInfo.SystemOs : targetOs));
     }
 
     public DirectoryInfo GetReleaseDirectory()

--- a/src/Velopack.Vpk/Commands/_PackCommand.cs
+++ b/src/Velopack.Vpk/Commands/_PackCommand.cs
@@ -53,8 +53,8 @@ public abstract class PackCommand : PlatformCommand
 
     protected CliOption<bool> NoInstOption { get; private set; }
 
-    public PackCommand(string name, string description)
-        : base(name, description)
+    public PackCommand(string name, string description, RuntimeOs targetOs = RuntimeOs.Unknown)
+        : base(name, description, targetOs)
     {
         PackIdOption = AddOption<string>((v) => PackId = v, "--packId", "-u")
            .SetDescription("Unique Id for application bundle.")

--- a/src/Velopack.Vpk/Commands/_PlatformCommand.cs
+++ b/src/Velopack.Vpk/Commands/_PlatformCommand.cs
@@ -6,7 +6,7 @@ public abstract class PlatformCommand : OutputCommand
 
     protected CliOption<string> TargetRuntimeOption { get; private set; }
 
-    protected PlatformCommand(string name, string description) : base(name, description)
+    protected PlatformCommand(string name, string description, RuntimeOs targetOs = RuntimeOs.Unknown) : base(name, description, targetOs)
     {
         TargetRuntimeOption = AddOption<string>((v) => TargetRuntime = v, "-r", "--runtime")
             .SetDescription("The target runtime to build packages for.")


### PR DESCRIPTION
I saw another opportunity to instead include the channel into the VelopackDefaults but I think this better. 