### PR TITLE
Allow extending pre-defined sources from SDK

### DIFF
--- a/src/Velopack/Sources/SimpleFileSource.cs
+++ b/src/Velopack/Sources/SimpleFileSource.cs
@@ -24,7 +24,7 @@ namespace Velopack.Sources
         }
 
         /// <inheritdoc />
-        public Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
+        public virtual Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
         {
             if (!BaseDirectory.Exists) {
                 logger.Error($"The local update directory '{BaseDirectory.FullName}' does not exist.");
@@ -64,7 +64,7 @@ namespace Velopack.Sources
         }
 
         /// <inheritdoc />
-        public Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken)
+        public virtual Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken)
         {
             var releasePath = Path.Combine(BaseDirectory.FullName, releaseEntry.FileName);
             if (!File.Exists(releasePath))

--- a/src/Velopack/Sources/SimpleWebSource.cs
+++ b/src/Velopack/Sources/SimpleWebSource.cs
@@ -32,7 +32,7 @@ namespace Velopack.Sources
         }
 
         /// <inheritdoc />
-        public async Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
+        public async virtual Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null, VelopackAsset? latestLocalRelease = null)
         {
             var releaseFilename = Utility.GetVeloReleaseIndexName(channel);
             var uri = Utility.AppendPathToUri(BaseUri, releaseFilename);
@@ -61,7 +61,7 @@ namespace Velopack.Sources
         }
 
         /// <inheritdoc />
-        public async Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken)
+        public async virtual Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken)
         {
             if (releaseEntry == null) throw new ArgumentNullException(nameof(releaseEntry));
             if (localFile == null) throw new ArgumentNullException(nameof(localFile));

--- a/src/Velopack/Sources/VelopackFlowUpdateSource.cs
+++ b/src/Velopack/Sources/VelopackFlowUpdateSource.cs
@@ -29,7 +29,7 @@ namespace Velopack.Sources
         public IFileDownloader Downloader { get; }
 
         /// <inheritdoc />
-        public async Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null,
+        public async virtual Task<VelopackAssetFeed> GetReleaseFeed(ILogger logger, string channel, Guid? stagingId = null,
             VelopackAsset? latestLocalRelease = null)
         {
             Uri baseUri = new(BaseUri, $"v1.0/manifest/");
@@ -65,7 +65,7 @@ namespace Velopack.Sources
         }
 
         /// <inheritdoc />
-        public async Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken = default)
+        public async virtual Task DownloadReleaseEntry(ILogger logger, VelopackAsset releaseEntry, string localFile, Action<int> progress, CancellationToken cancelToken = default)
         {
             if (releaseEntry is null) throw new ArgumentNullException(nameof(releaseEntry));
             if (releaseEntry is not VelopackFlowReleaseAsset velopackRelease) {


### PR DESCRIPTION
## Summary
This PR converts methods of `VelopackFlowUpdateSource`, `SimpleWebSource` and `SimpleFileSource` to `virtual`.

## Requirement
In some cases I need to override and add pre-job or post-job without changing the main logic. Since the [Utility](https://github.com/velopack/velopack/blob/83dfef507311843849abdc388ac4be4cc513c5ea/src/Velopack/Internal/Utility.cs#L17) class is not public, it's not possible to duplicate code to add codes around it. This PR allows extending existing sources