### PR TITLE
Fixed: Fixed semver version check - 0.0.1 is now allowed with a release label (e.g. 0.0.1-beta)

### DIFF
--- a/src/lib-csharp/NuGet/NugetUtil.cs
+++ b/src/lib-csharp/NuGet/NugetUtil.cs
@@ -41,7 +41,7 @@ namespace Velopack.NuGet
         public static void ThrowIfVersionNotSemverCompliant(string version)
         {
             if (SemanticVersion.TryParse(version, out var parsed)) {
-                if (parsed < new SemanticVersion(0, 0, 1)) {
+                if (parsed < new SemanticVersion(0, 0, 1, parsed.Release)) {
                     throw new Exception($"Invalid package version '{version}', it must be >= 0.0.1.");
                 }
             } else {

--- a/test/Velopack.Packaging.Tests/ReleasePackageTests.cs
+++ b/test/Velopack.Packaging.Tests/ReleasePackageTests.cs
@@ -23,33 +23,6 @@
 //        {
 //        }
 
-//        [Theory]
-//        [InlineData("1.2.3")]
-//        [InlineData("1.2.3-alpha13")]
-//        [InlineData("1.2.3-alpha135")]
-//        [InlineData("0.0.1")]
-//        [InlineData("1.299656.3-alpha")]
-//        public void SemanticVersionParsesValidVersion(string ver)
-//        {
-//            NugetUtil.ThrowIfVersionNotSemverCompliant(ver);
-//            Assert.True(SemanticVersion.TryParse(ver, out var _));
-//        }
-
-//        [Theory]
-//        [InlineData("")]
-//        [InlineData("1")]
-//        [InlineData("0")]
-//        [InlineData("1.2.3.4")]
-//        [InlineData("1.2.3.4-alpha")]
-//        [InlineData("0.0.0.0")]
-//        [InlineData("0.0.0")]
-//        [InlineData("0.0")]
-//        [InlineData("0.0.0-alpha")]
-//        public void SemanticVersionThrowsInvalidVersion(string ver)
-//        {
-//            Assert.ThrowsAny<Exception>(() => NugetUtil.ThrowIfVersionNotSemverCompliant(ver));
-//        }
-
 //        [Fact]
 //        public void ReleasePackageIntegrationTest()
 //        {

--- a/test/Velopack.Tests/NugetUtilTests.cs
+++ b/test/Velopack.Tests/NugetUtilTests.cs
@@ -1,0 +1,36 @@
+﻿using NuGet.Versioning;
+using Velopack.NuGet;
+
+namespace Velopack.Tests;
+
+public class NugetUtilTests
+{
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("1.2.3-alpha13")]
+    [InlineData("1.2.3-alpha135")]
+    [InlineData("0.0.1")]
+    [InlineData("0.0.1-beta")]
+    [InlineData("0.0.1-beta01")]
+    [InlineData("1.299656.3-alpha")]
+    public void SemanticVersionParsesValidVersion(string ver)
+    {
+        NugetUtil.ThrowIfVersionNotSemverCompliant(ver);
+        Assert.True(SemanticVersion.TryParse(ver, out var _));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("1")]
+    [InlineData("0")]
+    [InlineData("1.2.3.4")]
+    [InlineData("1.2.3.4-alpha")]
+    [InlineData("0.0.0.0")]
+    [InlineData("0.0.0")]
+    [InlineData("0.0")]
+    [InlineData("0.0.0-alpha")]
+    public void SemanticVersionThrowsInvalidVersion(string ver)
+    {
+        Assert.ThrowsAny<Exception>(() => NugetUtil.ThrowIfVersionNotSemverCompliant(ver));
+    }
+}


### PR DESCRIPTION
Related Issue: #207