### PR TITLE
Fix `--packTitle` not considered for macOS bundles

### DIFF
--- a/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
@@ -14,7 +14,8 @@ public class OsxPackCommandRunner : PackageBuilder<OsxPackOptions>
 
     protected override Task<string> PreprocessPackDir(Action<int> progress, string packDir)
     {
-        var dir = TempDir.CreateSubdirectory(Options.PackId + ".app");
+        var packTitle = Options.PackTitle ?? Options.PackId;
+        var dir = TempDir.CreateSubdirectory(packTitle + ".app");
         bool deleteAppBundle = false;
         string appBundlePath = Options.PackDirectory;
         if (!Options.PackDirectory.EndsWith(".app", StringComparison.OrdinalIgnoreCase)) {

--- a/test/Velopack.Packaging.Tests/OsxPackTests.cs
+++ b/test/Velopack.Packaging.Tests/OsxPackTests.cs
@@ -1,0 +1,39 @@
+using System.Runtime.Versioning;
+using Velopack.Compression;
+
+namespace Velopack.Packaging.Tests;
+
+[SupportedOSPlatform("osx")]
+public class OsxPackTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public OsxPackTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [SkippableFact]
+    public void PackBuildUsesAppTitleAsBundleName()
+    {
+        Skip.IfNot(VelopackRuntimeInfo.IsOSX);
+
+        using var logger = _output.BuildLoggerFor<OsxPackTests>();
+
+        using var _1 = Utility.GetTempDirectory(out var tmpOutput);
+        using var _2 = Utility.GetTempDirectory(out var tmpReleaseDir);
+        using var _3 = Utility.GetTempDirectory(out var unzipDir);
+
+        const string id = "MyAppId";
+        const string title = "MyAppTitle";
+        const string channel = "asd123";
+
+        TestApp.PackTestApp(id, "0.0.1", string.Empty, tmpReleaseDir, logger, channel: channel, packTitle: title);
+
+        var portablePath = Path.Combine(tmpReleaseDir, $"{id}-{channel}-Portable.zip");
+        EasyZip.ExtractZipToDirectory(logger, portablePath, unzipDir);
+
+        var bundlePath = Path.Combine(unzipDir, $"{title}.app");
+        Assert.True(Directory.Exists(bundlePath));
+    }
+}

--- a/test/Velopack.Packaging.Tests/TestApp.cs
+++ b/test/Velopack.Packaging.Tests/TestApp.cs
@@ -9,7 +9,7 @@ namespace Velopack.Packaging.Tests;
 public static class TestApp
 {
     public static void PackTestApp(string id, string version, string testString, string releaseDir, ILogger logger,
-        string releaseNotes = null, string channel = null, RID targetRid = null)
+        string releaseNotes = null, string channel = null, RID targetRid = null, string packTitle = null)
     {
         targetRid ??= RID.Parse(VelopackRuntimeInfo.SystemRid);
 
@@ -40,6 +40,7 @@ public static class TestApp
                 var options = new WindowsPackOptions {
                     EntryExecutableName = "TestApp.exe",
                     ReleaseDir = new DirectoryInfo(releaseDir),
+                    PackTitle = packTitle,
                     PackId = id,
                     TargetRuntime = targetRid,
                     PackVersion = version,
@@ -53,6 +54,7 @@ public static class TestApp
                 var options = new OsxPackOptions {
                     EntryExecutableName = "TestApp",
                     ReleaseDir = new DirectoryInfo(releaseDir),
+                    PackTitle = packTitle,
                     PackId = id,
                     TargetRuntime = targetRid,
                     PackVersion = version,
@@ -70,6 +72,7 @@ public static class TestApp
                 var options = new LinuxPackOptions {
                     EntryExecutableName = "TestApp",
                     ReleaseDir = new DirectoryInfo(releaseDir),
+                    PackTitle = packTitle,
                     PackId = id,
                     TargetRuntime = targetRid,
                     PackVersion = version,


### PR DESCRIPTION
Fixes https://github.com/velopack/velopack/issues/186

Hello!

I believe this is only an issue on macOS, because no other system has zipped-up app bundles, but when executing a command of the form:
```
[osx] pack --packTitle="My App" --packId="myapp" --runtime="osx-arm64" ...
```
The output is currently:
```
myapp-osx-arm64-Portable.zip
   |- myapp.app
```
When it should be:
```
myapp-osx-arm64-Portable.zip
   |- My App.app
```

