### PR TITLE
fix semver version check - 0.0.1 is now allowed with a release label

### DIFF
--- a/src/vpk/Velopack.Vpk/Commands/SystemCommandLineExtensions.cs
+++ b/src/vpk/Velopack.Vpk/Commands/SystemCommandLineExtensions.cs
@@ -293,7 +293,7 @@ internal static class SystemCommandLineExtensions
                 string version = result.Tokens[i].Value;
                 //TODO: This is duplicating NugetUtil.ThrowIfVersionNotSemverCompliant
                 if (SemanticVersion.TryParse(version, out var parsed)) {
-                    if (parsed < new SemanticVersion(0, 0, 1)) {
+                    if (parsed < new SemanticVersion(0, 0, 1, parsed.Release)) {
                         result.AddError($"{result.IdentifierToken.Value} contains an invalid package version '{version}', it must be >= 0.0.1.");
                         break;
                     }


### PR DESCRIPTION
Hi, 
I noticed today that the error is still occurring for me
Looks like I modified the part of the code in #208 that is no longer used

sorry 😄 