### PR TITLE
Fix updater search path in DEBUG builds

### DIFF
--- a/src/vpk/Velopack.Packaging/HelperFile.cs
+++ b/src/vpk/Velopack.Packaging/HelperFile.cs
@@ -88,7 +88,7 @@ public static class HelperFile
     static HelperFile()
     {
 #if DEBUG
-        AddSearchPath(AppContext.BaseDirectory, "..", "..", "..", "src", "Rust", "target", "debug");
+        AddSearchPath(AppContext.BaseDirectory, "..", "..", "..", "target", "debug");
         AddSearchPath(AppContext.BaseDirectory, "..", "..", "..", "vendor");
         AddSearchPath(AppContext.BaseDirectory, "..", "..", "..", "artwork");
 #else


### PR DESCRIPTION
Perhaps I'm doing something wrong, if so let me know. The [build instructions](https://docs.velopack.io/contributing/compiling#release--build) appear to be out of date as the `src/Rust` folder doesn't exist and, going by the [Rust docs](https://doc.rust-lang.org/cargo/guide/build-cache.html#build-cache), the workspace root appears to be the repository root where [`Cargo.lock`](https://github.com/velopack/velopack/blob/ca71471cbd9893f2510c06ecd14225751d6b8116/Cargo.lock) is located.

Sample output on macOS:

```
~/Repos/velopack $ git clean -xdf
~/Repos/velopack $ cargo build -q
~/Repos/velopack $ find . -type f -perm +u=x -name "*update*"
./target/debug/update
./target/debug/deps/update-e139ada1f22d8d06
./.git/hooks/post-update.sample
./.git/hooks/update.sample
```
update.exe is placed in the same directory on Windows. I assume Linux will also behave correctly unless Cargo tooling is doing something crazy.
