### PR TITLE
Allow for skipping update check

### DIFF
--- a/src/vpk/Velopack.Vpk/Updates/UpdateChecker.cs
+++ b/src/vpk/Velopack.Vpk/Updates/UpdateChecker.cs
@@ -6,16 +6,20 @@ namespace Velopack.Vpk.Updates;
 public class UpdateChecker
 {
     private readonly ILogger _logger;
+    private readonly VelopackDefaults _defaults;
     private IPackageSearchMetadata _cache;
 
-    public UpdateChecker(ILogger logger)
+    public UpdateChecker(ILogger logger, VelopackDefaults defaults)
     {
         _logger = logger;
+        _defaults = defaults;
     }
 
     public async Task<bool> CheckForUpdates()
     {
+        if (_defaults.SkipUpdates) return false;
         try {
+
             var myVer = VelopackRuntimeInfo.VelopackNugetVersion;
             var isPre = myVer.IsPrerelease || myVer.HasMetadata;
 

--- a/src/vpk/Velopack.Vpk/VelopackDefaults.cs
+++ b/src/vpk/Velopack.Vpk/VelopackDefaults.cs
@@ -2,16 +2,18 @@
 
 public record VelopackDefaults
 {
+    public bool SkipUpdates { get; }
     public bool DefaultPromptValue { get; }
     public RuntimeOs TargetOs { get; }
 
     public VelopackDefaults(bool defaultPromptValue)
-        : this(defaultPromptValue, VelopackRuntimeInfo.SystemOs)
+        : this(defaultPromptValue, VelopackRuntimeInfo.SystemOs, true)
     {
     }
 
-    public VelopackDefaults(bool defaultPromptValue, RuntimeOs targetOs)
+    public VelopackDefaults(bool defaultPromptValue, RuntimeOs targetOs, bool skipUpdates)
     {
+        SkipUpdates = skipUpdates;
         DefaultPromptValue = defaultPromptValue;
         TargetOs = targetOs;
     }


### PR DESCRIPTION
This adds in a new option to the root of the vpk command to allow for skipping update checks.

This is often desirable for things like automations that don't want additional checks to be performed.