### PR TITLE
Fix issue with generating SetupBundle for large bundle

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/SetupBundle.cs
+++ b/src/vpk/Velopack.Packaging.Windows/SetupBundle.cs
@@ -143,7 +143,7 @@ public static class SetupBundle
     public static unsafe int SearchInFile(MemoryMappedViewAccessor accessor, byte[] searchPattern)
     {
         var safeBuffer = accessor.SafeMemoryMappedViewHandle;
-        return KMPSearch(searchPattern, (byte*) safeBuffer.DangerousGetHandle(), (int) safeBuffer.ByteLength);
+        return KMPSearch(searchPattern, (byte*) safeBuffer.DangerousGetHandle(), (long) safeBuffer.ByteLength);
     }
 
     public static unsafe int SearchInFile(string filePath, byte[] searchPattern)


### PR DESCRIPTION
Fix In SetupBundle.cs   FindBundleHeader will throw new Exception("PlaceHolderNotFoundInAppHostException"); in IsBundle() when building large installer > 2.5Gb on windows system
The search pattern was never found