### PR TITLE
Give signtool absolute paths to the files to sign

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -256,14 +256,14 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
         }
 
         if (!string.IsNullOrEmpty(signTemplate)) {
-            helper.Sign(rootDir, filePaths, signTemplate, signParallel, progress, true);
+            helper.Sign(filePaths, signTemplate, signParallel, progress, true);
         }
 
         // signtool.exe does not work if we're not on windows.
         if (!VelopackRuntimeInfo.IsWindows) return;
 
         if (!string.IsNullOrEmpty(signParams)) {
-            helper.Sign(rootDir, filePaths, signParams, signParallel, progress, false);
+            helper.Sign(filePaths, signParams, signParallel, progress, false);
         }
     }
 


### PR DESCRIPTION
We've recently updated to use [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations) and as part of the process `signtool` is given a [dlib DLL](https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations#download-and-install-the-trusted-signing-dlib-package) that implements the signing function.

The complete setup looks like this: https://github.com/ppy/osu-deploy/blob/c8c9b70b0e1ad14711ae8976a86f4644c72cf15d/Builders/WindowsBuilder.cs#L32-L52

Importantly, the Azure signing dlib is a .NET 6 module. For us, it was failing to load with the exception:
```
Unhandled managed exception
System.TypeLoadException: Could not load type 'Internal.Runtime.CompilerServices.Unsafe' from assembly 'System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
```

It looks like this is caused by `signtool` being run inside the Velopack output directory and, since we target .NET 8, it was loading .NET libraries from the current directory that it is not actually compatible with.

The simple solution for us is to give `signtool` absolute file paths, though I'm not sure how digestible this sort of change is...