### PR TITLE
Fixing double runs when pushing to a branch with an open PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [ push, pull_request ]
+on: 
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+  workflow_dispatch:
 
 env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Right now if you push to a branch with an open PR, both the PR and an push triggers fire, causing the workflow to run twice. This limits it to only run on pushes to develop and master, or on PRs to those branches.
This also adds in a workflow_dispatch trigger to be able to manually kick runs from any branch if desired.
