### PR TITLE
Fix WithFirstRun not running on MacOS

### DIFF
--- a/src/vpk/Velopack.Packaging.Unix/OsxBuildTools.cs
+++ b/src/vpk/Velopack.Packaging.Unix/OsxBuildTools.cs
@@ -116,7 +116,7 @@ public class OsxBuildTools
 #!/bin/sh
 rm -rf /tmp/velopack/{appId}
 sudo -u "$USER" rm -rf ~/Library/Caches/velopack/{appId}
-sudo -u "$USER" open "$2/{bundleName}/"
+export VELOPACK_FIRSTRUN=1 sudo -u "$USER" open "$2/{bundleName}/"
 exit 0
 """);
         Chmod.ChmodFileAsExecutable(postinstall);

--- a/src/vpk/Velopack.Packaging.Unix/OsxBuildTools.cs
+++ b/src/vpk/Velopack.Packaging.Unix/OsxBuildTools.cs
@@ -116,7 +116,7 @@ public class OsxBuildTools
 #!/bin/sh
 rm -rf /tmp/velopack/{appId}
 sudo -u "$USER" rm -rf ~/Library/Caches/velopack/{appId}
-export VELOPACK_FIRSTRUN=1 sudo -u "$USER" open "$2/{bundleName}/"
+sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/{bundleName}/"
 exit 0
 """);
         Chmod.ChmodFileAsExecutable(postinstall);


### PR DESCRIPTION
I have had trouble setting up my dev environment to correctly build the vpk CLI to test this change works. 

Added a prefix of `export VELOPACK_FIRSTRUN=1` to the initial run of the installed app triggered in the postinstall script.
In theory, this should be available to Velopack to detect first run.

Closes #167 