### PR TITLE
Increased azure repository network timeout to 30 minutes

### DIFF
--- a/src/vpk/Velopack.Deployment/AzureRepository.cs
+++ b/src/vpk/Velopack.Deployment/AzureRepository.cs
@@ -39,10 +39,13 @@ public class AzureRepository : ObjectRepository<AzureDownloadOptions, AzureUploa
         }
 
         BlobServiceClient client;
+        BlobClientOptions clientOptions = new BlobClientOptions();
+        clientOptions.Retry.NetworkTimeout = TimeSpan.FromMinutes(30);
+
         if (!String.IsNullOrEmpty(options.SasToken)) {
-            client = new BlobServiceClient(new Uri(serviceUrl), new Azure.AzureSasCredential(options.SasToken));
+            client = new BlobServiceClient(new Uri(serviceUrl), new AzureSasCredential(options.SasToken), clientOptions);
         } else {
-            client = new BlobServiceClient(new Uri(serviceUrl), new StorageSharedKeyCredential(options.Account, options.Key));
+            client = new BlobServiceClient(new Uri(serviceUrl), new StorageSharedKeyCredential(options.Account, options.Key), clientOptions);
         }
         return client.GetBlobContainerClient(options.Container);
     }


### PR DESCRIPTION
Overriden the default BlobClient options to change the network timeout from 100 seconds to 30 minutes.

should fix #377