### PR TITLE
Add app id query string parameter in SimpleWebSource.DownloadReleaseEntry()

### DIFF
--- a/src/lib-csharp/Sources/QueryMode.cs
+++ b/src/lib-csharp/Sources/QueryMode.cs
@@ -1,0 +1,28 @@
+﻿namespace Velopack.Sources
+{
+    /// <summary>
+    /// Mode determining when query string parameters should be appended to a URL.
+    /// </summary>
+    public enum QueryMode
+    {
+        /// <summary>
+        /// Default value. No query string parameters will be appended to the URL.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// No query string parameters will be appended to the URL.
+        /// </summary>
+        NoQuery,
+
+        /// <summary>
+        /// Only release feed query string parameters will be appended to the URL.
+        /// </summary>
+        ReleaseFeedOnly,
+
+        /// <summary>
+        /// All request query string parameters will be appended to the URL.
+        /// </summary>
+        AllRequests
+    }
+}

--- a/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
+++ b/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
@@ -71,7 +71,7 @@ internal class FakeFixtureRepository : Sources.IFileDownloader
             return Task.FromResult(Encoding.UTF8.GetBytes(json));
         }
 
-        var rel = _releases.FirstOrDefault(r => url.EndsWith(r.OriginalFilename));
+        var rel = _releases.FirstOrDefault(r => url.Split('?')[0].EndsWith(r.OriginalFilename));
         if (rel == null)
             throw new Exception("Fake release not found: " + url);
 
@@ -86,7 +86,7 @@ internal class FakeFixtureRepository : Sources.IFileDownloader
     public Task DownloadFile(string url, string targetFile, Action<int> progress, string authorization = null, string accept = null, CancellationToken token = default)
     {
         LastUrl = url;
-        var rel = _releases.FirstOrDefault(r => url.EndsWith(r.OriginalFilename));
+        var rel = _releases.FirstOrDefault(r => url.Split('?')[0].EndsWith(r.OriginalFilename));
         var filePath = PathHelper.GetFixture(rel.OriginalFilename);
         if (!File.Exists(filePath)) {
             throw new NotSupportedException("FakeFixtureRepository doesn't have: " + rel.OriginalFilename);

--- a/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
+++ b/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
@@ -9,6 +9,8 @@ namespace Velopack.Tests.TestHelpers;
 
 internal class FakeFixtureRepository : Sources.IFileDownloader
 {
+    public string LastUrl { get; private set; }
+
     private readonly string _pkgId;
     private readonly IEnumerable<ReleaseEntry> _releases;
     private readonly VelopackAssetFeed _releasesNew;
@@ -57,6 +59,7 @@ internal class FakeFixtureRepository : Sources.IFileDownloader
 
     public Task<byte[]> DownloadBytes(string url, string authorization = null, string accept = null)
     {
+        LastUrl = url;
         if (url.Contains($"/{_releasesName}?")) {
             MemoryStream ms = new MemoryStream();
             ReleaseEntry.WriteReleaseFile(_releases, ms);
@@ -82,6 +85,7 @@ internal class FakeFixtureRepository : Sources.IFileDownloader
 
     public Task DownloadFile(string url, string targetFile, Action<int> progress, string authorization = null, string accept = null, CancellationToken token = default)
     {
+        LastUrl = url;
         var rel = _releases.FirstOrDefault(r => url.EndsWith(r.OriginalFilename));
         var filePath = PathHelper.GetFixture(rel.OriginalFilename);
         if (!File.Exists(filePath)) {
@@ -98,6 +102,7 @@ internal class FakeFixtureRepository : Sources.IFileDownloader
 
     public Task<string> DownloadString(string url, string authorization = null, string accept = null)
     {
+        LastUrl = url;
         if (url.Contains($"/{_releasesName}?")) {
             MemoryStream ms = new MemoryStream();
             ReleaseEntry.WriteReleaseFile(_releases, ms);

--- a/test/Velopack.Tests/UpdateManagerTests.cs
+++ b/test/Velopack.Tests/UpdateManagerTests.cs
@@ -511,5 +511,6 @@ public class UpdateManagerTests
         await um.DownloadUpdatesAsync(info);
         var target = Path.Combine(packagesDir, $"{id}-{toVersion}-full.nupkg");
         Assert.True(File.Exists(target));
+        Assert.Contains($"id={id}", repo.LastUrl);
     }
 }


### PR DESCRIPTION
Fixes #381 

As mentioned in the issue above, I have a scenario where it would be convenient for me to have the app ID passed as a query string parameter when the `SimpleWebSource.DownloadReleaseEntry()` is invoked as part of the app-update process.

This PR:
1. extends an existing test with an assertion for said query string parameter (red/green testing),
2. adds the required code in `SimpleWebSource.DownloadReleaseEntry()` to amend the query string,
3. makes minor modifications to existing tests/fixtures to compensate for the URL now containing a query string.