### PR TITLE
Adding --signExclude parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,7 @@ jobs:
         run: |
           sudo apt-cache search libwxgt*
           sudo apt-cache search libgtk*
-          sudo apt install -y libwxgtk3.0-gtk3-dev libgtk-3-dev
+          sudo apt install -y libwxgtk3.2-dev libgtk-3-dev
         if: ${{ matrix.sample == 'CPlusPlusWidgets' && matrix.os == 'ubuntu-latest' }}
       - name: Install VPK
         run: dotnet tool install -g vpk

--- a/src/vpk/Velopack.Build/PackTask.cs
+++ b/src/vpk/Velopack.Build/PackTask.cs
@@ -82,7 +82,7 @@ public class PackTask : MSBuildAsyncTask
     public string? SignParameters { get; set; }
     public string? AzureTrustedSignFile { get; set; }
 
-    public bool SignSkipDll { get; set; }
+    public string? SignExclude { get; set; }
 
     public int SignParallel { get; set; } = 10;
 

--- a/src/vpk/Velopack.Build/Velopack.Build.targets
+++ b/src/vpk/Velopack.Build/Velopack.Build.targets
@@ -86,7 +86,7 @@
       SplashImage="$(VelopackSplashImage)"
       SkipVelopackAppCheck="$(VelopackSkipVelopackAppCheck)"
       SignParameters="$(VelopackSignParameters)"
-      SignSkipDll="$(VelopackSignSkipDll)"
+      SignExclude="$(VelopackSignExclude)"
       SignParallel="$(VelopackSignParallel)"
       SignTemplate="$(VelopackSignTemplate)"
       Categories="$(VelopackCategories)"

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Velopack.Compression;
 using Velopack.Core;
@@ -18,8 +19,9 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
 
     protected override Task CodeSign(Action<int> progress, string packDir)
     {
+        Regex fileExcludeRegex = Options.SignExclude != null ? new Regex(Options.SignExclude) : null;
         var filesToSign = new DirectoryInfo(packDir).GetAllFilesRecursively()
-            .Where(x => Options.SignSkipDll ? PathUtil.PathPartEndsWith(x.Name, ".exe") : PathUtil.FileIsLikelyPEImage(x.Name))
+            .Where(x => !fileExcludeRegex?.IsMatch(x.FullName) ?? PathUtil.FileIsLikelyPEImage(x.Name))
             .Select(x => x.FullName)
             .ToArray();
 

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsSigningOptions.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsSigningOptions.cs
@@ -4,7 +4,7 @@ public class WindowsSigningOptions
 {
     public string SignParameters { get; set; }
 
-    public bool SignSkipDll { get; set; }
+    public string SignExclude { get; set; }
 
     public int SignParallel { get; set; }
 

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
@@ -10,11 +10,12 @@ public class WindowsPackCommand : PackCommand
 
     public string SignParameters { get; private set; }
 
-    public bool SignSkipDll { get; private set; }
+    public string SignExclude { get; private set; }
 
     public int SignParallel { get; private set; }
 
     public string SignTemplate { get; private set; }
+
     public string AzureTrustedSignFile { get; private set; }
 
     public string Shortcuts { get; private set; }
@@ -42,8 +43,8 @@ public class WindowsPackCommand : PackCommand
           .SetDescription("Use a custom signing command. {{file}} will be substituted.")
           .SetArgumentHelpName("COMMAND");
 
-        AddOption<bool>((v) => SignSkipDll = v, "--signSkipDll")
-            .SetDescription("Only signs EXE files, and skips signing DLL files.")
+        AddOption<string>((v) => SignExclude = v, "--signExclude")
+            .SetDescription("A regex which excludes matched files from signing.")
             .SetHidden();
 
         AddOption<int>((v) => SignParallel = v, "--signParallel")

--- a/test/Velopack.CommandLine.Tests/Commands/WindowsCommandTests.cs
+++ b/test/Velopack.CommandLine.Tests/Commands/WindowsCommandTests.cs
@@ -265,14 +265,14 @@ public class PackWindowsCommandTests : ReleaseCommandTests<WindowsPackCommand>
     }
 
     [WindowsOnlyFact]
-    public void SignSkipDll_BareOption_SetsFlag()
+    public void SignExclude_WithPattern_SetsOption()
     {
         var command = new WindowsPackCommand();
 
-        string cli = GetRequiredDefaultOptions() + "--signSkipDll";
+        string cli = GetRequiredDefaultOptions() + @"--signExclude \.dll$";
         ParseResult parseResult = command.ParseAndApply(cli);
 
-        Assert.True(command.SignSkipDll);
+        Assert.Equal(@"\.dll$", command.SignExclude);
     }
 
     [WindowsOnlyFact]


### PR DESCRIPTION
This allows the caller to specify a regex pattern to exclude files. When specified the default filter no longer applies.
