### PR TITLE
Fixing vulnerable NuGet packages

### DIFF
--- a/src/vpk/Velopack.Packaging/Velopack.Packaging.csproj
+++ b/src/vpk/Velopack.Packaging/Velopack.Packaging.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
     <PackageReference Include="Markdig" Version="0.40.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.67.1" />

--- a/test/LegacyTestApp/LegacyTestApp.csproj
+++ b/test/LegacyTestApp/LegacyTestApp.csproj
@@ -4,6 +4,11 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
+
+    <!--
+    NU1902: Vulnerable, obsolete packages ar eintentionally used as this is a demonstration of an old app
+    -->
+    <NoWarn>$(NoWarn);NU1902</NoWarn>
     <!--<UseClowd>2.11.1</UseClowd>-->
     <!--<UseClowd>3.0.210-*</UseClowd>-->
     <!--<UseVelopack>0.0.84</UseVelopack>-->


### PR DESCRIPTION
Updating transitive System.Text.Json package.
Ignoring vulnerable package in legacy app.

PR #462 has the fix needed for the pipeline.
