### PR TITLE
Fixing URL links

### DIFF
--- a/src/bins/src/setup.rs
+++ b/src/bins/src/setup.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
 fn main_inner() -> Result<()> {
     #[rustfmt::skip]
     let mut arg_config = Command::new("Setup")
-        .about(format!("Velopack Setup ({}) installs applications.\nhttps://github.com/velopack/velopack", env!("NGBV_VERSION")))
+        .about(format!("Velopack Setup ({}) installs applications.\nhttps:/velopack.io", env!("NGBV_VERSION")))
         .arg(arg!(-s --silent "Hides all dialogs and answers 'yes' to all prompts"))
         .arg(arg!(-v --verbose "Print debug messages to console"))
         .arg(arg!(-l --log <FILE> "Enable file logging and set location").required(false).value_parser(value_parser!(PathBuf)))

--- a/src/bins/src/update.rs
+++ b/src/bins/src/update.rs
@@ -14,7 +14,7 @@ use velopack_bins::{*, shared::OperationWait};
 fn root_command() -> Command {
     let cmd = Command::new("Update")
     .version(env!("NGBV_VERSION"))
-    .about(format!("Velopack Updater ({}) manages packages and installs updates.\nhttps://github.com/velopack/velopack", env!("NGBV_VERSION")))
+    .about(format!("Velopack Updater ({}) manages packages and installs updates.\nhttps:/velopack.io", env!("NGBV_VERSION")))
     .subcommand(Command::new("apply")
         .about("Applies a staged / prepared update, installing prerequisite runtimes if necessary")
         .arg(arg!(--norestart "Do not restart the application after the update"))

--- a/src/lib-csharp/Windows/Runtimes.cs
+++ b/src/lib-csharp/Windows/Runtimes.cs
@@ -7,7 +7,7 @@ namespace Velopack.Windows
     /// <summary>
     /// Contains static properties to access common supported runtimes, and a function to search for a runtime by name
     /// </summary>
-    [Obsolete("These classes are no longer used by Velopack, and does not represent the current supported runtimes. https://github.com/velopack/velopack/blob/master/docs/bootstrapping.md")]
+    [Obsolete("These classes are no longer used by Velopack, and does not represent the current supported runtimes. https://docs.velopack.io/packaging/bootstrapping")]
     public static partial class Runtimes
     {
         /// <summary> Runtime for .NET Framework 4.5 </summary>

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -169,7 +169,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
 #pragma warning restore CS0618 // Type or member is obsolete
 
             throw new UserInfoException(
-                $"The framework/runtime dependency '{str}' is not valid. See https://github.com/velopack/velopack/blob/master/docs/bootstrapping.md");
+                $"The framework/runtime dependency '{str}' is not valid. See https://docs.velopack.io/packaging/bootstrapping");
         }
 
         foreach (var str in validated) {

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
@@ -27,7 +27,7 @@ public class WindowsPackCommand : PackCommand
         IconOption.RequiresExtension(".ico");
 
         AddOption<string>((v) => Runtimes = v, "-f", "--framework")
-            .SetDescription("List of required runtimes to install during setup. Example: 'net6-x64-desktop,vcredist143'.")
+            .SetDescription("List of required runtimes to install during setup. Example: 'net6-x64-desktop,vcredist143-x64'.")
             .SetArgumentHelpName("RUNTIMES");
 
         AddOption<FileInfo>((v) => SplashImage = v.ToFullNameOrNull(), "-s", "--splashImage")


### PR DESCRIPTION
The bootstrapping link has been brokens since we moved docs to its own repo. This instead uses the docs web page address.
Redirected CLI output to point to the web site rather than the repo URL.
