### PR TITLE
Fix --signTemplate on Linux

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
+++ b/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
@@ -119,7 +119,7 @@ public class CodeSign
         if (!VelopackRuntimeInfo.IsWindows) {
             fileName = "/bin/bash";
             string escapedCommand = command.Replace("'", "'\\''");
-            args = $"-c '{escapedCommand} >> \"{signLogFile}\" 2>&1'";
+            args = $"-c \"{escapedCommand} >> \\\"{signLogFile}\\\" 2>&1\"";
         }
 
         var psi = new ProcessStartInfo {


### PR DESCRIPTION
Change how args are escaped for RunSigningCommand to fix issue with `'` on Linux