### PR TITLE
Windows Custom URL Protocol Support

### DIFF
--- a/src/bins/src/commands/apply_windows_impl.rs
+++ b/src/bins/src/commands/apply_windows_impl.rs
@@ -142,6 +142,9 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, run_
                 if let Err(e) = crate::windows::registry::remove_uninstall_entry(&old_locator) {
                     warn!("Failed to remove old uninstall entry ({}).", e);
                 }
+                if let Err(e) = crate::windows::registry::remove_all_custom_protocols(&old_locator) {
+                    warn!("Failed to remove custom URL protocol entries ({}).", e);
+                }
             }
             if let Err(e) = crate::windows::registry::write_uninstall_entry(&new_locator) {
                 warn!("Failed to write new uninstall entry ({}).", e);
@@ -166,6 +169,11 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, run_
 
         if !old_locator.get_is_portable() {
             crate::windows::create_or_update_manifest_lnks(&new_locator, Some(old_locator));
+        }
+
+        // update custom url protocols
+        if !old_locator.get_is_portable() {
+            let _ = crate::windows::registry::create_or_update_custom_protocols(&new_locator, Some(old_locator));
         }
 
         // done!

--- a/src/bins/src/commands/install.rs
+++ b/src/bins/src/commands/install.rs
@@ -188,7 +188,7 @@ fn install_impl(pkg: &mut BundleZip, locator: &VelopackLocator, tx: &std::sync::
 
     if !locator.get_custom_url_protocols().is_empty() {
         info!("Registering custom URL protocols...");
-        windows::registry::write_custom_url_protocols(&locator)?;
+        windows::registry::create_or_update_custom_protocols(&locator, None)?;
     }
 
     info!("Starting process install hook");

--- a/src/bins/src/commands/install.rs
+++ b/src/bins/src/commands/install.rs
@@ -186,6 +186,11 @@ fn install_impl(pkg: &mut BundleZip, locator: &VelopackLocator, tx: &std::sync::
         windows::create_or_update_manifest_lnks(&locator, None);
     }
 
+    if !locator.get_custom_url_protocols().is_empty() {
+        info!("Registering custom URL protocols...");
+        windows::registry::write_custom_url_protocols(&locator)?;
+    }
+
     info!("Starting process install hook");
     if !windows::run_hook(&locator, constants::HOOK_CLI_INSTALL, 30) {
         let setup_name = format!("{} Setup {}", locator.get_manifest_title(), locator.get_manifest_id());

--- a/src/bins/src/commands/uninstall.rs
+++ b/src/bins/src/commands/uninstall.rs
@@ -35,6 +35,11 @@ pub fn uninstall(locator: &VelopackLocator, delete_self: bool) -> Result<()> {
             // finished_with_errors = true;
         }
 
+        if let Err(e) = windows::registry::remove_all_custom_protocols(&locator) {
+            error!("Unable to remove custom URL protocol entries ({}).", e);
+            // finished_with_errors = true;
+        }
+
         !finished_with_errors
     }
 

--- a/src/bins/src/windows/registry.rs
+++ b/src/bins/src/windows/registry.rs
@@ -1,32 +1,107 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::{Datelike, Local as DateTime};
 use velopack::locator::VelopackLocator;
 use winsafe::{self as w, co, prelude::*};
+use std::collections::HashSet;
 
 const UNINSTALL_REGISTRY_KEY: &'static str = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
 const SOFTWARE_CLASSES_REGISTRY_KEY: &'static str = "Software\\Classes";
 // Sub key for setting the command line that the shell invokes
 // https://learn.microsoft.com/en-us/windows/win32/com/shell
-const SHELL_OPEN_COMMAND_KEY: &'static str = "Shell\\Open\\Command";
+const SHELL_OPEN_COMMAND_KEY: &'static str = "shell\\open\\command";
 
-pub fn write_custom_url_protocols(locator: &VelopackLocator) -> Result<()> {
-    let custom_url_protocols = locator.get_custom_urlProtocols();
-    if !custom_url_protocols.is_empty() {
-        let app_id = locator.get_manifest_id();
-        let main_exe_path = locator.get_main_exe_path_as_string();
-        // Software/Classes seems like standard place to put the shell open command, uncertain if it *must* be there
-        let app_protocols_key = format!("{}\\{}", SOFTWARE_CLASSES_REGISTRY_KEY, app_id);
-        let reg_app_protocols
-            = w::HKEY::CURRENT_USER.RegCreateKeyEx(app_protocols_key, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None)?.0;
+pub fn create_or_update_custom_protocols(next_app: &VelopackLocator, previous_app: Option<&VelopackLocator>) -> Result<()> {
+    info!("Writing custom protocol registry keys...");
+    let prev_custom_url_protocols = previous_app.map(|a| a.get_custom_url_protocols()).unwrap_or(Vec::<String>::new());
+    let next_custom_url_protocols = next_app.get_custom_url_protocols();
 
-        for protocol_name in custom_url_protocols {
-            let protocol_shell_open_cmd = format!("\"{}\" \"%1\"", main_exe_path);
-            let reg_protocol = reg_app_protocols.CREATE_SUB_KEY(protocol_name, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None)?.0;
-            let reg_shell_open_command
-                = reg_protocol.CREATE_SUB_KEY(SHELL_OPEN_COMMAND_KEY, None, co::REG_OPTION::NoValue, co::KEY::ALL_ACCESS, None)?.0;
-            reg_shell_open_command.RegSetKeyValue(None, Some("CustomURLProtocol"), w::RegistryValue::Sz(protocol_shell_open_cmd));
-        }
+    if prev_custom_url_protocols.is_empty() && next_custom_url_protocols.is_empty() {
+        return Ok(());
     }
+    if prev_custom_url_protocols == next_custom_url_protocols {
+        return Ok(());
+    }
+
+    let mut removable_protocols = prev_custom_url_protocols;
+    let mut new_protocols = next_custom_url_protocols;
+
+    // Do the following only if both are not empty, if one is empty then we're either removing all of one or adding all of one:
+    if !removable_protocols.is_empty() && !new_protocols.is_empty() {
+        let prev_protocols: HashSet<_> = removable_protocols.into_iter().collect();
+        let next_protocols: HashSet<_> = new_protocols.into_iter().collect();
+
+        // Get only the old protocols that needs to be removed from the previous app:
+        removable_protocols = prev_protocols.difference(&next_protocols).cloned().collect();
+        // Get only the new protocols from the next app that were not part of the previosu app:
+        new_protocols = next_protocols.difference(&prev_protocols).cloned().collect();
+    }
+
+    // Open registry key to Software/Classes, where the app's custom URL protocols will be stored:
+    let reg_software_classes_key =
+        w::HKEY::CURRENT_USER.RegCreateKeyEx(SOFTWARE_CLASSES_REGISTRY_KEY, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None).map_err(|e| anyhow!("Failed to create/open registry key: {}", e))?.0;
+    
+    // Remove unused protocols
+    let _ = remove_custom_protocols(&reg_software_classes_key, &removable_protocols);
+
+    // Create new protocols
+    let _ = register_custom_protocols(next_app, &reg_software_classes_key, &new_protocols);
+
+    Ok(())
+}
+
+fn remove_custom_protocols(reg_software_classes_key: &w::HKEY, protocols: &Vec<String>) -> Result<()> {
+    if protocols.is_empty() {
+        return Ok(());
+    }
+
+    for protocol_name in protocols {
+        // let reg_protocol_key = reg_software_classes_key.RegCreateKeyEx(&protocol_name, None, co::REG_OPTION::NoValue, co::KEY::ALL_ACCESS, None).map_err(|e| anyhow!("Failed to open key for protocol {}: {}", &protocol_name, e))?;
+        // reg_protocol_key.delete_key_recursive().map_err(|e| anyhow!("Failed to recursively delete protocol {}: {}", &protocol_name, e))?;
+        reg_software_classes_key.RegDeleteTree(Some(&protocol_name)).map_err(|e| anyhow!("Failed to recursively delete protocol {}: {}", &protocol_name, e))?;
+    }
+    Ok(())
+}
+
+fn register_custom_protocols(locator: &VelopackLocator, reg_software_classes_key: &w::HKEY, new_protocols: &Vec<String>) -> Result<()> {
+    if new_protocols.is_empty() {
+        return Ok(());
+    }
+
+    let main_exe_path = locator.get_main_exe_path_as_string();
+    let app_shell_open_cmd = format!("\"{}\" \"%1\"", main_exe_path);
+
+    for protocol_name in new_protocols {
+        let _ = register_single_protocol(&reg_software_classes_key, &protocol_name, &app_shell_open_cmd);
+    }
+    Ok(())
+}
+
+fn register_single_protocol(reg_software_classes_key: &w::HKEY, protocol_name: &String, app_shell_open_cmd: &String) -> Result<()> {
+    // Create registry key for the protocol
+    let reg_protocol_sub_key = reg_software_classes_key.RegCreateKeyEx(&protocol_name, None, co::REG_OPTION::NoValue, co::KEY::ALL_ACCESS, None).map_err(|e| anyhow!("Failed to create subkey for protocol {}: {}", &protocol_name, e))?.0;
+
+    // This seems like standard practice, to add these values for URL protocols.
+    reg_protocol_sub_key.RegSetKeyValue(None, Some(""), w::RegistryValue::Sz(format!("URL:{} protocol", &protocol_name)))?;
+    reg_protocol_sub_key.RegSetKeyValue(None, Some("URL Protocol"), w::RegistryValue::Sz(String::new()))?;
+
+    // Create registry key for the shell open command
+    let reg_protocol_open_sub_key
+        = reg_protocol_sub_key.RegCreateKeyEx(SHELL_OPEN_COMMAND_KEY, None, co::REG_OPTION::NoValue, co::KEY::ALL_ACCESS, None).map_err(|e| anyhow!("Failed to create shell open command subkey for protocol {}: {}", &protocol_name, e))?.0;
+
+    // Set value
+    reg_protocol_open_sub_key.RegSetKeyValue(None, Some(""), w::RegistryValue::Sz(app_shell_open_cmd.to_string())).map_err(|e| anyhow!("Failed to set shell open command for protocol {}: {}", &protocol_name, e))?;
+    Ok(())
+}
+
+pub fn remove_all_custom_protocols(locator: &VelopackLocator) -> Result<()> {
+    info!("Removing custom protocols registry keys...");
+    // Open registry key to Software/Classes, where the app's custom URL protocols will be stored:
+    let reg_software_classes_key =
+        w::HKEY::CURRENT_USER.RegCreateKeyEx(SOFTWARE_CLASSES_REGISTRY_KEY, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None).map_err(|e| anyhow!("Failed to create/open registry key: {}", e))?.0;
+
+    let protocols = locator.get_custom_url_protocols();
+    let _ = remove_custom_protocols(&reg_software_classes_key, &protocols);
+
     Ok(())
 }
 
@@ -74,8 +149,5 @@ pub fn remove_uninstall_entry(locator: &VelopackLocator) -> Result<()> {
     let reg_uninstall =
         w::HKEY::CURRENT_USER.RegCreateKeyEx(UNINSTALL_REGISTRY_KEY, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None)?.0;
     reg_uninstall.RegDeleteKey(&app_id)?;
-    let reg_app_protocols =
-        w::HKEY::CURRENT_USER.RegCreateKeyEx(SOFTWARE_CLASSES_REGISTRY_KEY, None, co::REG_OPTION::NoValue, co::KEY::CREATE_SUB_KEY, None)?.0;
-    reg_app_protocols.RegDeleteKey(&app_id)
     Ok(())
 }

--- a/src/lib-cpp/include/Velopack.h
+++ b/src/lib-cpp/include/Velopack.h
@@ -1,7 +1,7 @@
 #ifndef VELOPACK_H
 #define VELOPACK_H
 
-/* Generated with cbindgen:0.27.0 */
+/* Generated with cbindgen:0.28.0 */
 
 /* THIS FILE IS AUTO-GENERATED - DO NOT EDIT */
 

--- a/src/lib-csharp/NuGet/PackageManifest.cs
+++ b/src/lib-csharp/NuGet/PackageManifest.cs
@@ -28,6 +28,7 @@ namespace Velopack.NuGet
         public string? Summary { get; private set; }
         public string? Copyright { get; private set; }
         public string? ShortcutAmuid { get; private set; }
+        public IEnumerable<string> CustomUrlProtocols { get; private set; } = Enumerable.Empty<string>();
         public IEnumerable<string> ShortcutLocations { get; private set; } = Enumerable.Empty<string>();
         public IEnumerable<string> Authors { get; private set; } = Enumerable.Empty<string>();
         public IEnumerable<string> RuntimeDependencies { get; private set; } = Enumerable.Empty<string>();
@@ -144,6 +145,9 @@ namespace Velopack.NuGet
                 break;
             case "shortcutAmuid":
                 ShortcutAmuid = value;
+                break;
+            case "customUrlProtocols":
+                CustomUrlProtocols = getCommaDelimitedValue(value);
                 break;
             }
         }

--- a/src/lib-csharp/Windows/RuntimeInfo.cs
+++ b/src/lib-csharp/Windows/RuntimeInfo.cs
@@ -162,7 +162,7 @@ namespace Velopack.Windows
             }
         }
 
-        /// <summary> Represents a modern DOTNET runtime where versions are deployed independenly of the operating system </summary>
+        /// <summary> Represents a modern DOTNET runtime where versions are deployed independently of the operating system </summary>
         public class DotnetInfo : RuntimeInfo
         {
             /// <inheritdoc/>

--- a/src/lib-rust/src/bundle.rs
+++ b/src/lib-rust/src/bundle.rs
@@ -355,6 +355,7 @@ pub struct Manifest {
     pub shortcut_amuid: String,
     pub release_notes: String,
     pub release_notes_html: String,
+    pub custom_url_protocols: String,
 }
 
 /// Parse manifest object from an XML string.
@@ -403,6 +404,8 @@ pub fn read_manifest_from_string(xml: &str) -> Result<Manifest, Error> {
                     obj.release_notes = text;
                 } else if el_name == "releaseNotesHtml" {
                     obj.release_notes_html = text;
+                } else if el_name == "customUrlProtocols" {
+                    obj.custom_url_protocols = text;
                 }
             }
             Ok(XmlEvent::EndElement { .. }) => {

--- a/src/lib-rust/src/locator.rs
+++ b/src/lib-rust/src/locator.rs
@@ -262,6 +262,13 @@ impl VelopackLocator {
         Some(self.manifest.shortcut_amuid.clone())
     }
 
+    /// Returns the list of custom URL protocols to register for the application
+    pub fn get_custom_url_protocols(&self) -> Vec<String> {
+        self.manifest.custom_url_protocols.split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    }
+
     /// Returns a copy of the current VelopackLocator with the manifest field set to the given manifest.
     pub fn clone_self_with_new_manifest(&self, manifest: &Manifest) -> VelopackLocator
     {

--- a/src/vpk/Velopack.Build/PackTask.cs
+++ b/src/vpk/Velopack.Build/PackTask.cs
@@ -94,6 +94,8 @@ public class PackTask : MSBuildAsyncTask
     
     public string? Compression { get; set; }
 
+    public string? CustomUrlProtocols { get; set; }
+
     protected override async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
     {
         //System.Diagnostics.Debugger.Launch();

--- a/src/vpk/Velopack.Build/Velopack.Build.targets
+++ b/src/vpk/Velopack.Build/Velopack.Build.targets
@@ -92,6 +92,7 @@
       Categories="$(VelopackCategories)"
       Shortcuts="$(VelopackShortcuts)"
       Compression="$(VelopackAppImageCompression)"
+      CustomUrlProtocols="$(VelopackCustomUrlProtocols)"
     />
   </Target>
 

--- a/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
@@ -37,4 +37,6 @@ public class LinuxPackOptions : IPackOptions
     public string Categories { get; set; }
     
     public string Compression { get; set; }
+
+    public string CustomUrlProtocols { get; set; }
 }

--- a/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackOptions.cs
@@ -35,4 +35,6 @@ public class OsxPackOptions : OsxBundleOptions, IPackOptions
     public string Channel { get; set; }
 
     public string Exclude { get; set; }
+
+    public string CustomUrlProtocols { get; set; }
 }

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -43,6 +43,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
         ExtraNuspecMetadata["runtimeDependencies"] = GetRuntimeDependencies();
         ExtraNuspecMetadata["shortcutLocations"] = GetShortcutLocations();
         ExtraNuspecMetadata["shortcutAmuid"] = CoreUtil.GetAppUserModelId(Options.PackId);
+        ExtraNuspecMetadata["customUrlProtocols"] = GetCustomUrlProtocols();
 
         // copy files to temp dir, so we can modify them
         var dir = TempDir.CreateSubdirectory("PreprocessPackDirWin");
@@ -177,6 +178,30 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions>
         }
 
         return String.Join(",", validated);
+    }
+
+    protected string GetCustomUrlProtocols()
+    {
+        if (String.IsNullOrWhiteSpace(Options.CustomUrlProtocols))
+            return null;
+
+        try {
+            var customUrlProtocols = Options.CustomUrlProtocols.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Distinct()
+                .ToList();
+
+            if (customUrlProtocols.Count == 0)
+                return null;
+
+            var customUrlProtocolsString = string.Join(",", customUrlProtocols);
+            Log.Debug($"Custom URL Protocols: { customUrlProtocolsString } ");
+            return customUrlProtocolsString;
+        } catch (Exception ex) {
+            throw new UserInfoException(
+                $"Invalid custom url protocols '{Options.CustomUrlProtocols}'. " +
+                $"Error was {ex.Message}");
+        }
     }
 
     protected override Task CreateSetupPackage(Action<int> progress, string releasePkg, string packDir, string targetSetupExe)

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
@@ -23,4 +23,6 @@ public class WindowsPackOptions : WindowsReleasifyOptions, INugetPackCommand, IP
     public bool NoInst { get; set; }
 
     public string Shortcuts { get; set; }
+
+    public string CustomUrlProtocols { get; set; }
 }

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/LinuxPackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/LinuxPackCommand.cs
@@ -13,6 +13,7 @@ public class LinuxPackCommand : PackCommand
     {
         this.RemoveOption(NoPortableOption);
         this.RemoveOption(NoInstOption);
+        this.RemoveOption(CustomUrlProtocolsOption);
 
         AddOption<string>((v) => Categories = v, "--categories")
             .SetDescription("Categories from the freedesktop.org Desktop Menu spec")

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/OsxBundleCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/OsxBundleCommand.cs
@@ -13,6 +13,7 @@ public class OsxBundleCommand : PackCommand
         RemoveOption(NoInstOption);
         RemoveOption(ReleaseNotesOption);
         RemoveOption(DeltaModeOption);
+        RemoveOption(CustomUrlProtocolsOption);
     }
 
     public OsxBundleCommand(string name, string description)

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/PackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/PackCommand.cs
@@ -53,6 +53,10 @@ public abstract class PackCommand : PlatformCommand
 
     protected CliOption<bool> NoInstOption { get; private set; }
 
+    public string CustomUrlProtocols { get; private set; }
+
+    protected CliOption<string> CustomUrlProtocolsOption { get; private set; }
+
     public PackCommand(string name, string description, RuntimeOs targetOs = RuntimeOs.Unknown)
         : base(name, description, targetOs)
     {
@@ -112,6 +116,9 @@ public abstract class PackCommand : PlatformCommand
         NoInstOption = AddOption<bool>((v) => NoInst = v, "--noInst")
             .SetDescription("Skip generating an installer package.")
             .SetHidden(true);
+
+        CustomUrlProtocolsOption = AddOption<string>((v) => CustomUrlProtocols = v, "--customUrlProtocols")
+            .SetDescription("Custom protocol names to register for the application.");
 
         this.AreMutuallyExclusive(NoPortableOption, NoInstOption);
     }

--- a/test/TestApp/Const.cs
+++ b/test/TestApp/Const.cs
@@ -1,1 +1,1 @@
-class Const { public const string TEST_STRING = "Hello, World!"; }
+﻿class Const { public const string TEST_STRING = "Hello, World!"; }

--- a/test/Velopack.Packaging.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Packaging.Tests/WindowsPackTests.cs
@@ -250,16 +250,17 @@ public class WindowsPackTests
 
         // Check custom url protocols exist
         string softwareClassesRegSubKey = @"Software\Classes";
+        string shellOpenCommandRegSubKey = @"shell\\open\\command";
         string expectedProtocolValue = "\"" + appPath + "\" \"%1\"";
-        string protocolValue1 = null; 
-        string protocolValue2 = null; 
         using (var protocolKey1 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
-            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol1 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
-            protocolValue1 = protocolKey1.GetValue("") as string;
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol1 + "\\" + shellOpenCommandRegSubKey, RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            string protocolValue = protocolKey1.GetValue("") as string;
+            Assert.Equal(expectedProtocolValue, protocolValue);
         }
         using (var protocolKey2 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
-            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol2 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
-            protocolValue2 = protocolKey2.GetValue("") as string;
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol2 + "\\" + shellOpenCommandRegSubKey, RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            string protocolValue = protocolKey2.GetValue("") as string;
+            Assert.Equal(expectedProtocolValue, protocolValue);
         }
 
         var uninstOutput = RunNoCoverage(updatePath, new string[] { "--silent", "--uninstall" }, Environment.CurrentDirectory, logger);
@@ -268,9 +269,6 @@ public class WindowsPackTests
         Assert.False(File.Exists(startLnk));
         Assert.False(File.Exists(desktopLnk));
         Assert.False(File.Exists(appPath));
-
-        Assert.Equal(expectedProtocolValue, protocolValue1);
-        Assert.Equal(expectedProtocolValue, protocolValue2);
 
         using (var key2 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
                    .OpenSubKey(uninstallRegSubKey + "\\" + id, RegistryKeyPermissionCheck.ReadSubTree)) {

--- a/test/Velopack.Packaging.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Packaging.Tests/WindowsPackTests.cs
@@ -191,6 +191,9 @@ public class WindowsPackTests
         PathHelper.CopyRustAssetTo(exe, tmpOutput);
         PathHelper.CopyRustAssetTo(pdb, tmpOutput);
 
+        var customProtocol1 = "testsquirrelapp";
+        var customProtocol2 = "testapp";
+
         var options = new WindowsPackOptions {
             EntryExecutableName = exe,
             ReleaseDir = new DirectoryInfo(tmpReleaseDir),
@@ -199,6 +202,7 @@ public class WindowsPackTests
             TargetRuntime = RID.Parse("win-x64"),
             PackDirectory = tmpOutput,
             Shortcuts = "Desktop,StartMenuRoot",
+            CustomUrlProtocols = customProtocol1 + "," + customProtocol2,
         };
 
         var runner = GetPackRunner(logger);
@@ -244,6 +248,20 @@ public class WindowsPackTests
         var date = DateTime.Now.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         Assert.Equal(date, installDate.Trim('\0'));
 
+        // Check custom url protocols exist
+        string softwareClassesRegSubKey = @"Software\Classes";
+        string expectedProtocolValue = "\"" + appPath + "\" \"%1\"";
+        string protocolValue1 = null; 
+        string protocolValue2 = null; 
+        using (var protocolKey1 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol1 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            protocolValue1 = protocolKey1.GetValue("") as string;
+        }
+        using (var protocolKey2 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol2 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            protocolValue2 = protocolKey2.GetValue("") as string;
+        }
+
         var uninstOutput = RunNoCoverage(updatePath, new string[] { "--silent", "--uninstall" }, Environment.CurrentDirectory, logger);
         Assert.EndsWith(Environment.NewLine + "Y", uninstOutput); // this checks that the self-delete succeeded
 
@@ -251,9 +269,82 @@ public class WindowsPackTests
         Assert.False(File.Exists(desktopLnk));
         Assert.False(File.Exists(appPath));
 
+        Assert.Equal(expectedProtocolValue, protocolValue1);
+        Assert.Equal(expectedProtocolValue, protocolValue2);
+
         using (var key2 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
                    .OpenSubKey(uninstallRegSubKey + "\\" + id, RegistryKeyPermissionCheck.ReadSubTree)) {
             Assert.Null(key2);
+        }
+
+        // Check that protocols have been removed:
+        using (var protocolKey1 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol1, RegistryKeyPermissionCheck.ReadSubTree)) {
+            Assert.Null(protocolKey1);
+        }
+        using (var protocolKey2 = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocol2, RegistryKeyPermissionCheck.ReadSubTree)) {
+            Assert.Null(protocolKey2);
+        }
+    }
+
+    [SkippableFact]
+    public void TestAppCustomProtocolUpdatesWhenLocalIsAvailable()
+    {
+        Skip.IfNot(VelopackRuntimeInfo.IsWindows);
+        using var logger = _output.BuildLoggerFor<WindowsPackTests>();
+        using var _1 = TempUtil.GetTempDirectory(out var releaseDir);
+        using var _2 = TempUtil.GetTempDirectory(out var installDir);
+        string id = "SquirrelCustomProtocolTest";
+        var appPath = Path.Combine(installDir, "current", "TestApp.exe");
+        string customProtocolVersion1 = "testsquirrelapp1";
+        string customProtocolVersion2 = "testsquirrelapp2";
+
+        // pack v1
+        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, customProtocolVersion1, logger);
+
+        // install app
+        var setupPath1 = Path.Combine(releaseDir, $"{id}-win-Setup.exe");
+        RunNoCoverage(
+            setupPath1,
+            new string[] { "--silent", "--installto", installDir },
+            Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+            logger);
+
+        // Check custom url protocol with v1 exist
+        string softwareClassesRegSubKey = @"Software\Classes";
+        string expectedProtocolValue = "\"" + appPath + "\" \"%1\"";
+        using (var protocolKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocolVersion1 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            string protocolValue = protocolKey.GetValue("") as string;
+            Assert.Equal(expectedProtocolValue, protocolValue);
+        }
+
+        // pack v2
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, customProtocolVersion2, logger);
+
+        // move package into local packages dir
+        var fileName = $"{id}-2.0.0-full.nupkg";
+        var mvFrom = Path.Combine(releaseDir, fileName);
+        var mvTo = Path.Combine(installDir, "packages", fileName);
+        File.Copy(mvFrom, mvTo);
+
+        RunCoveredDotnet(appPath, new string[] { "--autoupdate" }, installDir, logger, exitCode: null);
+
+        Thread.Sleep(3000); // update.exe runs in separate process
+
+        var chk1version = RunCoveredDotnet(appPath, new string[] { "version" }, installDir, logger);
+        Assert.EndsWith(Environment.NewLine + "2.0.0", chk1version);
+
+        // Check custom url for v1 is gone and v2 is there
+        using (var protocolKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocolVersion1 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            Assert.Null(protocolKey);
+        }
+        using (var protocolKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
+            .OpenSubKey(softwareClassesRegSubKey + "\\" + customProtocolVersion2 + "\\shell\\open\\command", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
+            string protocolValue = protocolKey.GetValue("") as string;
+            Assert.Equal(expectedProtocolValue, protocolValue);
         }
     }
 
@@ -268,7 +359,7 @@ public class WindowsPackTests
         var appPath = Path.Combine(installDir, "current", "TestApp.exe");
 
         // pack v1
-        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, logger);
+        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, "", logger);
 
         // install app
         var setupPath1 = Path.Combine(releaseDir, $"{id}-win-Setup.exe");
@@ -279,7 +370,7 @@ public class WindowsPackTests
             logger);
 
         // pack v2
-        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger);
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, "", logger);
 
         // move package into local packages dir
         var fileName = $"{id}-2.0.0-full.nupkg";
@@ -302,9 +393,9 @@ public class WindowsPackTests
         Skip.IfNot(VelopackRuntimeInfo.IsWindows);
         using var logger = _output.BuildLoggerFor<WindowsPackTests>();
         string id = "SquirrelDeltaTest";
-        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, logger);
-        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger, true);
-        PackTestApp(id, "3.0.0", "version 3 test", releaseDir, logger);
+        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, "", logger);
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, "", logger, true);
+        PackTestApp(id, "3.0.0", "version 3 test", releaseDir, "", logger);
 
         // did a zsdiff get created for our v2 update?
         var deltaPath = Path.Combine(releaseDir, $"{id}-2.0.0-delta.nupkg");
@@ -379,7 +470,7 @@ public class WindowsPackTests
         var appPath = Path.Combine(installDir, "current", "TestApp.exe");
 
         // pack v1
-        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, logger);
+        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, "", logger);
 
         // install app
         var setupPath1 = Path.Combine(releaseDir, $"{id}-win-Setup.exe");
@@ -398,7 +489,7 @@ public class WindowsPackTests
         Assert.Equal("1.0.0", File.ReadAllText(firstRun).Trim());
 
         // pack v2
-        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger);
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, "", logger);
 
         // install v2
         RunCoveredDotnet(appPath, ["download", releaseDir], installDir, logger);
@@ -431,7 +522,7 @@ public class WindowsPackTests
         string id = "SquirrelIntegrationTest";
 
         // pack v1
-        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, logger);
+        PackTestApp(id, "1.0.0", "version 1 test", releaseDir, "", logger);
 
         // install app
         var setupPath1 = Path.Combine(releaseDir, $"{id}-win-Setup.exe");
@@ -460,7 +551,7 @@ public class WindowsPackTests
         logger.Info("TEST: v1 output verified");
 
         // pack v2
-        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, logger);
+        PackTestApp(id, "2.0.0", "version 2 test", releaseDir, "", logger);
 
         // check can find v2 update
         var chk2check = RunCoveredDotnet(appPath, new string[] { "check", releaseDir }, installDir, logger);
@@ -468,7 +559,7 @@ public class WindowsPackTests
         logger.Info("TEST: found v2 update");
 
         // pack v3
-        PackTestApp(id, "3.0.0", "version 3 test", releaseDir, logger);
+        PackTestApp(id, "3.0.0", "version 3 test", releaseDir, "", logger);
 
         // corrupt v2/v3 full packages as we want to test delta's
         File.WriteAllText(Path.Combine(releaseDir, $"{id}-2.0.0-win-full.nupkg"), "nope");
@@ -541,7 +632,7 @@ public class WindowsPackTests
             retryDelay: 1000);
 
         using var _1 = TempUtil.GetTempDirectory(out var releaseDir);
-        PackTestApp("LegacyTestApp", "2.0.0", "hello!", releaseDir, logger);
+        PackTestApp("LegacyTestApp", "2.0.0", "hello!", releaseDir, "", logger);
 
         RunNoCoverage(appExe, new string[] { "download", releaseDir }, currentDir, logger, exitCode: 0);
         RunNoCoverage(appExe, new string[] { "apply", releaseDir }, currentDir, logger, exitCode: null);
@@ -727,7 +818,7 @@ public class WindowsPackTests
         return RunImpl(psi, logger, exitCode);
     }
 
-    private void PackTestApp(string id, string version, string testString, string releaseDir, ILogger logger, bool addNewFile = false)
+    private void PackTestApp(string id, string version, string testString, string releaseDir , string customProtocols, ILogger logger, bool addNewFile = false)
     {
         var projDir = PathHelper.GetTestRootPath("TestApp");
         var testStringFile = Path.Combine(projDir, "Const.cs");
@@ -768,6 +859,7 @@ public class WindowsPackTests
                 PackVersion = version,
                 TargetRuntime = RID.Parse("win-x64"),
                 PackDirectory = Path.Combine(projDir, "publish"),
+                CustomUrlProtocols = customProtocols,
             };
 
             var runner = GetPackRunner(logger);


### PR DESCRIPTION
Added ability to specify custom URL protocols for Windows application, I don't know Linux/MacOS so wasn't sure what needed to be done there... I may take a look at it and see though.

This allows you to add multiple custom URL protocols and if you create a new version with a different set of protocols, it will remove the old ones and add the new ones.

The new pack command option is set at the shared level and removed from Linux & OSx, not sure if this makes sense since I'm not familiar with the code base.

I also modified the `PackBuildsPackageWhichIsInstallable` test and added a new test specifically for this (basically copied from the shortcuts one).

Let me know what you think!
