### PR TITLE
Velopack Flow API fix

### DIFF
--- a/src/vpk/Velopack.Flow/VelopackFlowServiceClient.cs
+++ b/src/vpk/Velopack.Flow/VelopackFlowServiceClient.cs
@@ -100,7 +100,8 @@ public class VelopackFlowServiceClient(
         AssertAuthenticated();
 
         var client = GetHttpClient();
-        var endpoint = GetFlowApi().BaseUrl;
+        Uri baseUri = new(GetFlowApi().BaseUrl);
+        Uri endpoint = new(baseUri, endpointUri);
 
         HttpRequestMessage request = new(new HttpMethod(method), endpoint);
         if (body is not null) {


### PR DESCRIPTION
The base URI was not combined making the error message incorrect. 
This fixes the merging and Flow E2E tests now pass.