### PR TITLE
Fixed signDisableDeep complaining about sq.version

### DIFF
--- a/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
@@ -95,6 +95,9 @@ public class OsxPackCommandRunner : PackageBuilder<OsxPackOptions>
                 var structure = new OsxStructureBuilder(packDir);
                 var updateMacPath = Path.Combine(structure.MacosDirectory, "UpdateMac");
                 helper.CodeSign(Options.SignAppIdentity, entitlements, updateMacPath, false, keychainPath);
+                signProgress(25);
+                var versionPath = Path.Combine(structure.MacosDirectory, "sq.version");
+                helper.CodeSign(Options.SignAppIdentity, entitlements, versionPath, false, keychainPath);
                 signProgress(50);
                 
                 Log.Info("Code signing application bundle...");


### PR DESCRIPTION
Make sure to sign sq.version since it is inside of the Contents/MacOS. Otherwise signing will fail. Resolves: https://github.com/velopack/velopack/issues/507