### PR TITLE
Fix update lock after download interruption

### DIFF
--- a/src/lib-rust/src/download.rs
+++ b/src/lib-rust/src/download.rs
@@ -38,6 +38,10 @@ where
         }
     }
 
+    if downloaded < total_size.unwrap_or(0) {
+        return Err(Error::Generic("Download updates were interrupted.".to_owned()));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
If the download process of update packages is interrupted (due to network issues or the user closing the app), the "UpdateManager" still renames the download file and removes the ".partial" extension, resulting in an invalid package that cannot be applied and causing the download of the latest version to become locked.

Hi, I propose the following changes to address these issues, but you might have a clearer understanding of how to avoid them. Thanks anyway :)