### PR TITLE
This handles the case where the version is null on the latest asset

### DIFF
--- a/src/lib-csharp/Sources/VelopackFlowUpdateSource.cs
+++ b/src/lib-csharp/Sources/VelopackFlowUpdateSource.cs
@@ -52,7 +52,7 @@ namespace Velopack.Sources
             }
 
             if (latestLocalRelease != null) {
-                args.Add("localVersion", latestLocalRelease.Version.ToString());
+                args.Add("localVersion", latestLocalRelease.Version?.ToString() ?? "");
             }
 
             if (stagingId != null) {


### PR DESCRIPTION
In normal operation this should not happen, but could occur if someone manually creates the VelopackAsset instance.
