### PR TITLE
Add option forcePathStyle for s3 deployment

### DIFF
--- a/src/vpk/Velopack.Deployment/S3Repository.cs
+++ b/src/vpk/Velopack.Deployment/S3Repository.cs
@@ -24,7 +24,7 @@ public class S3DownloadOptions : RepositoryOptions, IObjectDownloadOptions
 
     public string Prefix { get; set; }
 
-    public bool ForcePathStyle { get; set; }
+    public bool DisablePathStyle { get; set; }
 }
 
 public class S3UploadOptions : S3DownloadOptions, IObjectUploadOptions
@@ -100,8 +100,8 @@ public class S3Repository : ObjectRepository<S3DownloadOptions, S3UploadOptions,
         bool disableSigning = false;
         var config = new AmazonS3Config() {
             ServiceURL = options.Endpoint,
-            ForcePathStyle = options.ForcePathStyle,
-            Timeout = TimeSpan.FromMinutes(options.Timeout)
+            ForcePathStyle = !options.DisablePathStyle, // default is ForcePathStyle = true, as it's more widely supported
+            Timeout = TimeSpan.FromMinutes(options.Timeout),
         };
 
         if (options.Endpoint != null) {

--- a/src/vpk/Velopack.Deployment/S3Repository.cs
+++ b/src/vpk/Velopack.Deployment/S3Repository.cs
@@ -23,6 +23,8 @@ public class S3DownloadOptions : RepositoryOptions, IObjectDownloadOptions
     public string Bucket { get; set; }
 
     public string Prefix { get; set; }
+
+    public bool ForcePathStyle { get; set; }
 }
 
 public class S3UploadOptions : S3DownloadOptions, IObjectUploadOptions
@@ -98,8 +100,8 @@ public class S3Repository : ObjectRepository<S3DownloadOptions, S3UploadOptions,
         bool disableSigning = false;
         var config = new AmazonS3Config() {
             ServiceURL = options.Endpoint,
-            ForcePathStyle = true, // support for MINIO
-            Timeout = TimeSpan.FromMinutes(options.Timeout),
+            ForcePathStyle = options.ForcePathStyle,
+            Timeout = TimeSpan.FromMinutes(options.Timeout)
         };
 
         if (options.Endpoint != null) {

--- a/src/vpk/Velopack.Vpk/Commands/Deployment/S3BaseCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Deployment/S3BaseCommand.cs
@@ -16,7 +16,7 @@ public class S3BaseCommand : OutputCommand
 
     public string Prefix { get; private set; }
 
-    public bool ForcePathStyle { get; private set; }
+    public bool DisablePathStyle { get; private set; }
 
     public double Timeout { get; private set; }
 
@@ -42,7 +42,7 @@ public class S3BaseCommand : OutputCommand
         region.Validators.Add(MustBeValidAwsRegion);
 
         var endpoint = AddOption<Uri>((v) => Endpoint = v.ToAbsoluteOrNull(), "--endpoint")
-            .SetDescription("Custom service url (backblaze, digital ocean, etc).")
+            .SetDescription("Custom S3-compatible service url (backblaze, digital ocean, etc).")
             .SetArgumentHelpName("URL")
             .MustBeValidHttpUri();
 
@@ -58,10 +58,9 @@ public class S3BaseCommand : OutputCommand
             .SetDescription("Prefix to the S3 url.")
             .SetArgumentHelpName("PREFIX");
 
-        AddOption<bool>((v) => ForcePathStyle = v, "--forcePathStyle")
-            .SetDescription("Force a path-style endpoint to be used where the bucket name is part of the path.")
-            .SetArgumentHelpName("BOOL")
-            .SetDefault(true);
+        AddOption<bool>((v) => DisablePathStyle = v, "--disablePathStyle")
+            .SetDescription("Disable the default of path-style endpoint and use a subdomain endpoint instead.")
+            .SetArgumentHelpName("BOOL");
 
         AddOption<double>((v) => Timeout = v, "--timeout")
             .SetDescription("Network timeout in minutes.")

--- a/src/vpk/Velopack.Vpk/Commands/Deployment/S3BaseCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Deployment/S3BaseCommand.cs
@@ -16,6 +16,8 @@ public class S3BaseCommand : OutputCommand
 
     public string Prefix { get; private set; }
 
+    public bool ForcePathStyle { get; private set; }
+
     public double Timeout { get; private set; }
 
     protected S3BaseCommand(string name, string description)
@@ -55,6 +57,11 @@ public class S3BaseCommand : OutputCommand
         AddOption<string>((v) => Prefix = v, "--prefix")
             .SetDescription("Prefix to the S3 url.")
             .SetArgumentHelpName("PREFIX");
+
+        AddOption<bool>((v) => ForcePathStyle = v, "--forcePathStyle")
+            .SetDescription("Force a path-style endpoint to be used where the bucket name is part of the path.")
+            .SetArgumentHelpName("BOOL")
+            .SetDefault(true);
 
         AddOption<double>((v) => Timeout = v, "--timeout")
             .SetDescription("Network timeout in minutes.")


### PR DESCRIPTION
`ForcePathStyle` may not be `true` all the time.
For example Alibaba Cloud OSS need's it be `false`.
so I make it configurable, and default to be `true`