### PR TITLE
Fix Squirrel CLI migrations by adding --updateSelf command

### DIFF
--- a/src/vpk/Velopack.Vpk/Velopack.Vpk.csproj
+++ b/src/vpk/Velopack.Vpk/Velopack.Vpk.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>vpk</AssemblyName>
     <LangVersion>latest</LangVersion>
+    <BuildInParallel>false</BuildInParallel> <!-- https://github.com/dotnet/sdk/issues/17454 -->
     <NoWarn>$(NoWarn);CA2007;CS8002</NoWarn>
   </PropertyGroup>
 

--- a/test/Velopack.Packaging.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Packaging.Tests/WindowsPackTests.cs
@@ -878,10 +878,13 @@ public class WindowsPackTests
 
         try {
             File.WriteAllText(testStringFile, $"class Const {{ public const string TEST_STRING = \"{testString}\"; }}");
-            var args = new string[] {
-                "publish", "--no-self-contained", "-c", "Release", "-r", "win-x64", "-o", "publish",
-                $"-p:PublishSingleFile=true", "--tl:off"
+            var args = new List<string> {
+                "publish", "--no-self-contained", "-c", "Release", "-r", "win-x64", "-o", "publish", "--tl:off"
             };
+
+            if (assemblyNameOverride != null) {
+                args.Add("-p:PublishSingleFile=true");
+            }
 
             var psi = new ProcessStartInfo("dotnet");
             psi.WorkingDirectory = projDir;
@@ -918,7 +921,7 @@ public class WindowsPackTests
             //RunNoCoverage("dotnet", args, projDir, logger);
 
             var options = new WindowsPackOptions {
-                EntryExecutableName = assemblyNameOverride + ".exe",
+                EntryExecutableName = (assemblyNameOverride ?? "TestApp") + ".exe",
                 ReleaseDir = new DirectoryInfo(releaseDir),
                 PackId = id,
                 PackVersion = version,


### PR DESCRIPTION
When using the Squirrel CLI to perform updates, Update.exe becomes locked and can not be updated. There is a mechanism in Squirrel to "--updateSelf" after the application update. This adds that command to Velopack.

Closes #632 