### PR TITLE
Refactor downloader methods to use a dictionary for headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
           merge-multiple: true
       - name: Azure login
         uses: azure/login@v2
-        if: github.repository == 'velopack/velopack'    
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/src/lib-csharp/Sources/GitBase.cs
+++ b/src/lib-csharp/Sources/GitBase.cs
@@ -35,12 +35,14 @@ namespace Velopack.Sources
         protected virtual string? AccessToken { get; }
 
         /// <summary>
-        /// The Bearer token used in the request.
+        /// The Bearer or other type of Authorization header used to authenticate against the Api.
         /// </summary>
-        protected virtual string? Authorization => string.IsNullOrWhiteSpace(AccessToken) ? null : "Bearer " + AccessToken;
+        protected abstract (string Name, string Value) Authorization { get; }
 
-        /// <inheritdoc />
-        public GitBase(string repoUrl, string? accessToken, bool prerelease, IFileDownloader? downloader = null)
+        /// <summary>
+        /// Base constructor.
+        /// </summary>
+        protected GitBase(string repoUrl, string? accessToken, bool prerelease, IFileDownloader? downloader = null)
         {
             RepoUri = new Uri(repoUrl.TrimEnd('/'));
             AccessToken = accessToken;
@@ -55,7 +57,12 @@ namespace Velopack.Sources
                 // this might be a browser url or an api url (depending on whether we have a AccessToken or not)
                 // https://docs.github.com/en/rest/reference/releases#get-a-release-asset
                 var assetUrl = GetAssetUrlFromName(githubEntry.Release, releaseEntry.FileName);
-                return Downloader.DownloadFile(assetUrl, localFile, progress, Authorization, "application/octet-stream", cancelToken: cancelToken);
+                return Downloader.DownloadFile(assetUrl, localFile, progress,
+                   new Dictionary<string, string> {
+                            [Authorization.Name] = Authorization.Value,
+                            ["Accept"] = "application/octet-stream"
+                        },
+                    cancelToken: cancelToken);
             }
 
             throw new ArgumentException($"Expected releaseEntry to be {nameof(GitBaseAsset)} but got {releaseEntry.GetType().Name}.");
@@ -84,7 +91,12 @@ namespace Velopack.Sources
                     logger.Trace(ex.ToString());
                     continue;
                 }
-                var releaseBytes = await Downloader.DownloadBytes(assetUrl, Authorization, "application/octet-stream").ConfigureAwait(false);
+                var releaseBytes = await Downloader.DownloadBytes(assetUrl,                    
+                    new Dictionary<string, string> {
+                        [Authorization.Name] = Authorization.Value,
+                        ["Accept"] = "application/octet-stream"
+                    }
+                ).ConfigureAwait(false);
                 var txt = CoreUtil.RemoveByteOrderMarkerIfPresent(releaseBytes);
                 var feed = VelopackAssetFeed.FromJson(txt);
                 foreach (var f in feed.Assets) {

--- a/src/lib-csharp/Sources/HttpClientFileDownloader.cs
+++ b/src/lib-csharp/Sources/HttpClientFileDownloader.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Velopack.Sources
 {
-
     /// <inheritdoc cref="IFileDownloader"/>
     public class HttpClientFileDownloader : IFileDownloader
     {
@@ -72,7 +71,7 @@ namespace Velopack.Sources
         {
             // https://stackoverflow.com/a/46497896/184746
             // Get the http headers first to examine the content length
-            using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancelToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var contentLength = response.Content.Headers.ContentLength;

--- a/src/lib-csharp/Sources/IFileDownloader.cs
+++ b/src/lib-csharp/Sources/IFileDownloader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,31 +15,26 @@ namespace Velopack.Sources
         /// </summary>
         /// <param name="url">The url which will be downloaded.</param>
         /// <param name="targetFile">
-        /// The local path where the file will be stored
-        /// If a file exists at this path, it will be overwritten.</param>
+        ///     The local path where the file will be stored
+        ///     If a file exists at this path, it will be overwritten.</param>
         /// <param name="progress">
-        /// A delegate for reporting download progress, with expected values from 0-100.
+        ///     A delegate for reporting download progress, with expected values from 0-100.
         /// </param>
-        /// <param name="authorization">
-        /// Text to be sent in the 'Authorization' header of the request.
-        /// </param>
-        /// <param name="accept">
-        /// Text to be sent in the 'Accept' header of the request.
-        /// </param>
+        /// <param name="headers">Headers that can be passed to Http Downloader, e.g. Accept or Authorization.</param>
         /// <param name="timeout">
-        /// The maximum time in minutes to wait for the download to complete.
+        ///     The maximum time in minutes to wait for the download to complete.
         /// </param>
         /// <param name="cancelToken">Optional token to cancel the request.</param>
-        Task DownloadFile(string url, string targetFile, Action<int> progress, string? authorization = null, string? accept = null, double timeout = 30, CancellationToken cancelToken = default);
+        Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string>? headers = null, double timeout = 30, CancellationToken cancelToken = default);
 
         /// <summary>
         /// Returns a byte array containing the contents of the file at the specified url
         /// </summary>
-        Task<byte[]> DownloadBytes(string url, string? authorization = null, string? accept = null, double timeout = 30);
+        Task<byte[]> DownloadBytes(string url, IDictionary<string, string>? headers = null, double timeout = 30);
 
         /// <summary>
         /// Returns a string containing the contents of the specified url
         /// </summary>
-        Task<string> DownloadString(string url, string? authorization = null, string? accept = null, double timeout = 30);
+        Task<string> DownloadString(string url, IDictionary<string, string>? headers = null, double timeout = 30);
     }
 }

--- a/test/Velopack.Tests/TestHelpers/FakeDownloader.cs
+++ b/test/Velopack.Tests/TestHelpers/FakeDownloader.cs
@@ -7,7 +7,7 @@ public class FakeDownloader : IFileDownloader
 {
     public string LastUrl { get; private set; }
     public string LastLocalFile { get; private set; }
-    public IDictionary<string, string>? LastHeaders { get; private set; }
+    public IDictionary<string, string> LastHeaders { get; private set; } = new Dictionary<string, string>();
     public byte[] MockedResponseBytes { get; set; } = [];
     public bool WriteMockLocalFile { get; set; } = false;
 

--- a/test/Velopack.Tests/TestHelpers/FakeDownloader.cs
+++ b/test/Velopack.Tests/TestHelpers/FakeDownloader.cs
@@ -7,23 +7,21 @@ public class FakeDownloader : IFileDownloader
 {
     public string LastUrl { get; private set; }
     public string LastLocalFile { get; private set; }
-    public string LastAuthHeader { get; private set; }
-    public string LastAcceptHeader { get; private set; }
+    public IDictionary<string, string>? LastHeaders { get; private set; }
     public byte[] MockedResponseBytes { get; set; } = [];
     public bool WriteMockLocalFile { get; set; } = false;
 
-    public Task<byte[]> DownloadBytes(string url, string auth, string acc, double timeout = 30)
+    public Task<byte[]> DownloadBytes(string url, IDictionary<string, string> headers, double timeout = 30)
     {
         LastUrl = url;
-        LastAuthHeader = auth;
-        LastAcceptHeader = acc;
+        LastHeaders = headers;
         return Task.FromResult(MockedResponseBytes);
     }
 
-    public async Task DownloadFile(string url, string targetFile, Action<int> progress, string auth, string acc, double timeout, CancellationToken token)
+    public async Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string> headers, double timeout = 30, CancellationToken token = default)
     {
         LastLocalFile = targetFile;
-        var resp = await DownloadBytes(url, auth, acc);
+        var resp = await DownloadBytes(url, headers);
         progress?.Invoke(25);
         progress?.Invoke(50);
         progress?.Invoke(75);
@@ -32,8 +30,8 @@ public class FakeDownloader : IFileDownloader
             File.WriteAllBytes(targetFile, resp);
     }
 
-    public async Task<string> DownloadString(string url, string auth, string acc, double timeout = 30)
+    public async Task<string> DownloadString(string url, IDictionary<string, string> headers, double timeout = 30)
     {
-        return Encoding.UTF8.GetString(await DownloadBytes(url, auth, acc));
+        return Encoding.UTF8.GetString(await DownloadBytes(url, headers));
     }
 }

--- a/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
+++ b/test/Velopack.Tests/TestHelpers/FakeFixtureRepository.cs
@@ -57,7 +57,7 @@ internal class FakeFixtureRepository : IFileDownloader
         _releases = releases;
     }
 
-    public Task<byte[]> DownloadBytes(string url, string authorization = null, string accept = null, double timeout = 30)
+    public Task<byte[]> DownloadBytes(string url, IDictionary<string, string> headers = null, double timeout = 30)
     {
         if (url.Contains($"/{_releasesName}?")) {
             MemoryStream ms = new MemoryStream();
@@ -82,7 +82,7 @@ internal class FakeFixtureRepository : IFileDownloader
         return Task.FromResult(File.ReadAllBytes(filePath));
     }
 
-    public Task DownloadFile(string url, string targetFile, Action<int> progress, string authorization = null, string accept = null, double timeout = 30,
+    public Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string> headers = null, double timeout = 30,
         CancellationToken token = default)
     {
         var rel = _releases.FirstOrDefault(r => url.EndsWith(r.OriginalFilename));
@@ -99,7 +99,7 @@ internal class FakeFixtureRepository : IFileDownloader
         return Task.CompletedTask;
     }
 
-    public Task<string> DownloadString(string url, string authorization = null, string accept = null, double timeout = 30)
+    public Task<string> DownloadString(string url, IDictionary<string, string> headers = null, double timeout = 30)
     {
         if (url.Contains($"/{_releasesName}?")) {
             MemoryStream ms = new MemoryStream();


### PR DESCRIPTION
@caesay this is my take on the changes related to header updates as discussed in #641

I explicitly wanted to split this so this update does NOT include the actual problematic changes related to the self hosted gitlab instance.

Also, I had some issues with unit tests on my machine. I'll need  to await a CI build (hopefully, there is one 😄 )

Attention: As discussed, this Api is breaking the API without fall back compatibility when using custom Downloaders.