### PR TITLE
Fix for self hosted Gitlab Url for Release Source

### DIFF
--- a/src/lib-csharp/Sources/GitlabSource.cs
+++ b/src/lib-csharp/Sources/GitlabSource.cs
@@ -157,16 +157,15 @@ namespace Velopack.Sources
             const int perPage = 10;
             const int page = 1;
             // https://docs.gitlab.com/ee/api/releases/
-            var releasesPath = $"{RepoUri.AbsolutePath}/releases?per_page={perPage}&page={page}";
-            var baseUri = new Uri("https://gitlab.com");
-            var getReleasesUri = new Uri(baseUri, releasesPath);
+            var releasesPath = $"releases?per_page={perPage}&page={page}";
+            var getReleasesUri = new Uri(RepoUri + releasesPath);
             var response = await Downloader.DownloadString(getReleasesUri.ToString(),
                 new Dictionary<string, string> {
                     [Authorization.Name] = Authorization.Value,
                     ["Accept"] = "application/json"
                 }).ConfigureAwait(false);
             var releases = CompiledJson.DeserializeGitlabReleaseList(response);
-            if (releases == null) return new GitlabRelease[0];
+            if (releases == null) return Array.Empty<GitlabRelease>();
             return releases.OrderByDescending(d => d.ReleasedAt).Where(x => includePrereleases || !x.UpcomingRelease).ToArray();
         }
     }

--- a/src/lib-csharp/Sources/GitlabSource.cs
+++ b/src/lib-csharp/Sources/GitlabSource.cs
@@ -158,7 +158,7 @@ namespace Velopack.Sources
             const int page = 1;
             // https://docs.gitlab.com/ee/api/releases/
             var releasesPath = $"releases?per_page={perPage}&page={page}";
-            var getReleasesUri = new Uri(RepoUri + releasesPath);
+            var getReleasesUri = CombineUri(RepoUri, releasesPath);
             var response = await Downloader.DownloadString(getReleasesUri.ToString(),
                 new Dictionary<string, string> {
                     [Authorization.Name] = Authorization.Value,
@@ -167,6 +167,16 @@ namespace Velopack.Sources
             var releases = CompiledJson.DeserializeGitlabReleaseList(response);
             if (releases == null) return Array.Empty<GitlabRelease>();
             return releases.OrderByDescending(d => d.ReleasedAt).Where(x => includePrereleases || !x.UpcomingRelease).ToArray();
+        }
+        
+        private static Uri CombineUri(Uri baseUri, string relativePath)
+        {
+            string baseUriStr = baseUri.ToString();
+
+            if (!baseUriStr.EndsWith("/"))
+                baseUriStr += "/";
+
+            return new Uri(baseUriStr + relativePath);
         }
     }
 }


### PR DESCRIPTION
Do not assume that that base Url is always https://gitlab.com and also, correctly handle potential trailing slash issue.