### PR TITLE
Use the default Windows color for progress bars on the splash screen

### DIFF
--- a/src/bins/src/windows/splash.rs
+++ b/src/bins/src/windows/splash.rs
@@ -227,7 +227,7 @@ impl SplashWindow {
 
             // draw progress bar to hdc_mem
             let progress = self2.progress.borrow();
-            let progress_brush = w::HBRUSH::CreateSolidBrush(w::COLORREF::new(0, 255, 0))?;
+            let progress_brush = w::HBRUSH::CreateSolidBrush(w::COLORREF::new(6, 176, 37))?;
             let progress_width = (rect.right as f32 * (*progress as f32 / 100.0)) as i32;
             let progress_rect = w::RECT { left: 0, bottom: rect.bottom, right: progress_width, top: rect.bottom - 10 };
             hdc_mem.FillRect(progress_rect, &progress_brush)?;


### PR DESCRIPTION
Currently the color of the progress bar on the splash window uses #00FF00 which stands out and looks like an obvious design mistake, even if seen for only a few seconds. This change proposes to instead use the color that Windows uses for its own progress bars. It is still green, but less bright, and something that users will be familiar with.

I determined the color to use by using a color picker tool on a Windows file copy dialog since that has flat parts without shading. The resulting color is #06B025, and it visually matches other progress bars (especially the one that is shown when no splash image is used). That color is also referenced directly by Microsoft as progress bar color here: https://github.com/dotnet/wpf/blob/4bd646467b69e97898fd126772d9dcdb8b1ed314/src/Microsoft.DotNet.Wpf/src/Themes/XAML/ProgressBar.xaml#L353