### PR TITLE
Fix Gitea Token problem

### DIFF
--- a/src/vpk/Velopack.Vpk/Velopack.Vpk.csproj
+++ b/src/vpk/Velopack.Vpk/Velopack.Vpk.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Gitea.Net.API" Version="25.3.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/test/Velopack.CommandLine.Tests/Velopack.CommandLine.Tests.csproj
+++ b/test/Velopack.CommandLine.Tests/Velopack.CommandLine.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Gitea.Net.API" Version="25.3.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\vpk\Velopack.Vpk\Velopack.Vpk.csproj" />
   </ItemGroup>
 

--- a/test/Velopack.Packaging.Tests/Velopack.Packaging.Tests.csproj
+++ b/test/Velopack.Packaging.Tests/Velopack.Packaging.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Gitea.Net.API" Version="25.3.5" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.14.0" />
     <PackageReference Include="System.Formats.Asn1" Version="9.0.5" />


### PR DESCRIPTION
Since Gitea 1.23 token must be in the header.
It's not more allowed to be in the URL.

> This authentication option is deprecated for removal in Gitea 1.23. Please use AuthorizationHeaderToken instead.

#708