### PR TITLE
Copy Icon to hicolor directory when packaging AppImage

### DIFF
--- a/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
@@ -34,6 +34,10 @@ public class LinuxPackCommandRunner : PackageBuilder<LinuxPackOptions>
             File.Copy(icon, Path.Combine(dir.FullName, iconFilename), true);
             File.Copy(icon, Path.Combine(dir.FullName, ".DirIcon"), true);
 
+            string iconDirPath = Path.Combine(dir.FullName, "usr", "share", "icons", "hicolor", "scalable", "apps");
+            Directory.CreateDirectory(iconDirPath);
+            File.Copy(icon, Path.Combine(iconDirPath, iconFilename), true);
+
             var categories = String.IsNullOrWhiteSpace(Options.Categories)
                 ? "Utility"
                 : Options.Categories.TrimEnd(';');


### PR DESCRIPTION
Added extra icon location within AppImage AppDir to try and fix #731 .

Closes #731 