### PR TITLE
Fixes tmpdir & AppImage writing issues

### DIFF
--- a/src/lib-csharp/Util/TempUtil.cs
+++ b/src/lib-csharp/Util/TempUtil.cs
@@ -9,17 +9,32 @@ namespace Velopack.Util
         {
             string tempDir;
 
-            if (VelopackRuntimeInfo.IsOSX || VelopackRuntimeInfo.IsLinux) {
-                tempDir = "/tmp/velopack";
-            } else if (VelopackRuntimeInfo.IsWindows) {
-                tempDir = Path.Combine(Path.GetTempPath(), "Velopack");
+            var velopackTemp = Environment.GetEnvironmentVariable("VELOPACK_TEMP");
+            if (!string.IsNullOrWhiteSpace(velopackTemp)) {
+                tempDir = velopackTemp;
             } else {
-                throw new PlatformNotSupportedException();
-            }
+                var tmpdir = Environment.GetEnvironmentVariable("TMPDIR");
+                var temp = Environment.GetEnvironmentVariable("TEMP");
+                var tmp = Environment.GetEnvironmentVariable("TMP");
 
-            if (Environment.GetEnvironmentVariable("VELOPACK_TEMP") is var squirrlTmp
-                && !string.IsNullOrWhiteSpace(squirrlTmp))
-                tempDir = squirrlTmp;
+                string? baseEnv = !string.IsNullOrWhiteSpace(tmpdir)
+                    ? tmpdir
+                    : !string.IsNullOrWhiteSpace(temp)
+                        ? temp
+                        : !string.IsNullOrWhiteSpace(tmp)
+                            ? tmp
+                            : null;
+
+                if (!string.IsNullOrWhiteSpace(baseEnv)) {
+                    tempDir = Path.Combine(baseEnv!, "velopack");
+                } else if (VelopackRuntimeInfo.IsWindows) {
+                    tempDir = Path.Combine(Path.GetTempPath(), "Velopack");
+                } else if (VelopackRuntimeInfo.IsOSX || VelopackRuntimeInfo.IsLinux) {
+                    tempDir = "/tmp/velopack";
+                } else {
+                    throw new PlatformNotSupportedException();
+                }
+            }
 
             var di = new DirectoryInfo(tempDir);
             if (!di.Exists) di.Create();

--- a/src/vpk/Velopack.Packaging.Unix/AppImageTool.cs
+++ b/src/vpk/Velopack.Packaging.Unix/AppImageTool.cs
@@ -66,9 +66,16 @@ public class AppImageTool
                     compression,
                     "-root-owned",
                     "-noappend",
-                    "-mkfs-time",
-                    "0",
                 ];
+
+                // If SOURCE_DATE_EPOCH is not set, pin filesystem time to 0 for determinism.
+                // When SOURCE_DATE_EPOCH is set, mksquashfs expects to control timestamps via env; do not pass -mkfs-time.
+                if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SOURCE_DATE_EPOCH"))) {
+                    args.AddRange([
+                        "-mkfs-time",
+                        "0"
+                    ]);
+                }
 
                 // see: https://github.com/AppImage/AppImageKit/blob/e8dadbb09fed3ae3c3d5a5a9ba2c47a072f71c40/src/appimagetool.c#L188-L195
                 if (compression == "xz") {
@@ -86,8 +93,26 @@ public class AppImageTool
 
             logger.Info($"Creating AppImage with {Path.GetFileName(runtime)} runtime");
             File.Copy(runtime, outputFile, true);
+            // Ensure the copied runtime is writable/executable before appending squashfs (works across TFMs)
+            Chmod.ChmodFileAsExecutable(outputFile);
 
-            using var outputfs = File.Open(outputFile, FileMode.Append);
+            // Ensure the copied runtime is writable before appending squashfs.
+            try {
+                if (VelopackRuntimeInfo.IsLinux) {
+#if NET8_0_OR_GREATER
+                    System.IO.File.SetUnixFileMode(
+                        outputFile,
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute
+                    );
+#endif
+                }
+            } catch {
+                // best-effort; ignore if setting permissions fails
+            }
+
+            using var outputfs = File.Open(outputFile, FileMode.Append, FileAccess.Write, FileShare.None);
             using var squashfs = File.OpenRead(tmpSquashFile);
             squashfs.CopyTo(outputfs);
 

--- a/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackCommandRunner.cs
@@ -21,9 +21,11 @@ public class LinuxPackCommandRunner : PackageBuilder<LinuxPackOptions>
         var dir = TempDir.CreateSubdirectory("PreprocessPackDir.AppDir");
         var bin = dir.CreateSubdirectory("usr").CreateSubdirectory("bin");
 
-        if (Options.PackDirectory.EndsWith(".AppDir", StringComparison.OrdinalIgnoreCase)) {
+        var packDirName = Options.PackDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var packDirBase = string.IsNullOrWhiteSpace(packDirName) ? Options.PackDirectory : packDirName;
+        if (Path.GetFileName(packDirBase).EndsWith(".AppDir", StringComparison.OrdinalIgnoreCase)) {
             Log.Info("Pack directory ends with .AppDir, will skip building new one.");
-            CopyFiles(new DirectoryInfo(Options.PackDirectory), dir, progress, true);
+            CopyFiles(new DirectoryInfo(packDirBase), dir, progress, true);
         } else {
             Log.Info("Building new AppDir from pack directory contents");
             var appRunPath = Path.Combine(dir.FullName, "AppRun");


### PR DESCRIPTION
This should fix #738 and #739 

```bash
$ VPK_LOG=trace ./result/bin/vpk pack --packId com.test.app --packVersion 0.0.1 --packDir ~/experiments/test-velopack/dist/linux-x64/test.AppDir/ --mainExe test --packTitle "Test" 2>&1 | tee vpk.log
[16:52:46 INF] Velopack CLI 0.0.0, for distributing applications.
[16:52:47 WRN] There is a newer version of vpk available (0.0.1298). Run 'dotnet tool update -g vpk'
[16:52:47 INF] Beginning to package Velopack release 0.0.1.
[16:52:47 INF] Releases Directory: /home/j/experiments/test-velopack/Releases
[16:52:47 INF] Starting: Pre-process steps
[16:52:47 INF] Pack directory ends with .AppDir, will skip building new one.
[16:52:47 INF] Complete: Pre-process steps
[16:52:47 INF] Starting: Building portable package
[16:52:47 INF] Compressing AppDir into squashfs filesystem
[16:52:48 INF] Creating AppImage with appimagekit-runtime-x86_64 runtime
[16:52:48 INF] Complete: Building portable package
[16:52:48 INF] Starting: Building release 0.0.1
[16:52:49 INF] Complete: Building release 0.0.1
[16:52:49 INF] Starting: Post-process steps
[16:52:49 INF] Complete: Post-process steps
[16:52:49 INF] Finished in 00:00:01.6071353.
[16:52:49 WRN] There is a newer version of vpk available (0.0.1298). Run 'dotnet tool update -g vpk'

$ ls Releases/
assets.linux.json                com.test.app.AppImage  releases.linux.json
com.test.app-0.0.1-linux-full.nupkg  RELEASES-linux
```