### PR TITLE
feat: implement GithubSource in Rust SDK

### DIFF
--- a/src/lib-rust/src/download.rs
+++ b/src/lib-rust/src/download.rs
@@ -4,12 +4,29 @@ use std::io::{Read, Write};
 use crate::{util, Error};
 
 /// Downloads a file from a URL and writes it to a file while reporting progress from 0-100.
-pub fn download_url_to_file<A>(url: &str, file_path: &str, mut progress: A) -> Result<(), Error>
+pub fn download_url_to_file<A>(url: &str, file_path: &str, progress: A) -> Result<(), Error>
+where
+    A: FnMut(i16),
+{
+    download_url_to_file_with_headers(url, file_path, &[], progress)
+}
+
+/// Downloads a file from a URL and returns it as a string.
+pub fn download_url_as_string(url: &str) -> Result<String, Error> {
+    download_url_as_string_with_headers(url, &[])
+}
+
+/// Downloads a file from a URL using custom headers and writes it to a file while reporting progress from 0-100.
+pub fn download_url_to_file_with_headers<A>(url: &str, file_path: &str, headers: &[(&str, &str)], mut progress: A) -> Result<(), Error>
 where
     A: FnMut(i16),
 {
     let agent = get_download_agent()?;
-    let (head, body) = agent.get(url).call()?.into_parts();
+    let mut req = agent.get(url);
+    for &(k, v) in headers {
+        req = req.header(k, v);
+    }
+    let (head, body) = req.call()?.into_parts();
 
     let total_size = head.headers.get("Content-Length").and_then(|s| s.to_str().ok()).and_then(|s| s.parse::<u64>().ok());
     let mut file = util::retry_io(|| File::create(file_path))?;
@@ -42,10 +59,14 @@ where
     Ok(())
 }
 
-/// Downloads a file from a URL and returns it as a string.
-pub fn download_url_as_string(url: &str) -> Result<String, Error> {
+/// Downloads a URL as a string with custom headers.
+pub fn download_url_as_string_with_headers(url: &str, headers: &[(&str, &str)]) -> Result<String, Error> {
     let agent = get_download_agent()?;
-    let r = agent.get(url).call()?.body_mut().read_to_string()?;
+    let mut req = agent.get(url);
+    for &(k, v) in headers {
+        req = req.header(k, v);
+    }
+    let r = req.call()?.body_mut().read_to_string()?;
     Ok(r)
 }
 
@@ -117,11 +138,7 @@ fn test_interrupted_download() {
     });
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
-    let result = download_url_to_file(
-        &format!("http://{}", addr),
-        tmpfile.path().to_str().unwrap(),
-        |_| {}
-    );
+    let result = download_url_to_file(&format!("http://{}", addr), tmpfile.path().to_str().unwrap(), |_| {});
 
     assert!(result.is_err(), "Download should fail due to connection interruption");
 }
@@ -152,11 +169,7 @@ fn test_successful_download() {
     });
 
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
-    let _ = download_url_to_file(
-        &format!("http://{}", addr),
-        tmpfile.path().to_str().unwrap(),
-        |_| {},
-    ).unwrap();
+    let _ = download_url_to_file(&format!("http://{}", addr), tmpfile.path().to_str().unwrap(), |_| {}).unwrap();
 
     // Verify that the downloaded file has the expected size
     let metadata = tmpfile.path().metadata().unwrap();

--- a/src/lib-rust/src/sources.rs
+++ b/src/lib-rust/src/sources.rs
@@ -3,8 +3,8 @@ use std::{
     sync::mpsc::Sender,
 };
 
-use crate::*;
 use crate::bundle::Manifest;
+use crate::*;
 
 /// Abstraction for finding and downloading updates from a package source / repository.
 /// An implementation may copy a file from a local repository, download from a web address,
@@ -25,7 +25,7 @@ impl Clone for Box<dyn UpdateSource> {
     }
 }
 
-/// A source that does not provide any update capability. 
+/// A source that does not provide any update capability.
 #[derive(Clone)]
 pub struct NoneSource {}
 
@@ -33,7 +33,12 @@ impl UpdateSource for NoneSource {
     fn get_release_feed(&self, _channel: &str, _app: &Manifest, _staged_user_id: &str) -> Result<VelopackAssetFeed, Error> {
         Err(Error::Generic("None source does not checking release feed".to_owned()))
     }
-    fn download_release_entry(&self, _asset: &VelopackAsset, _local_file: &str, _progress_sender: Option<Sender<i16>>) -> Result<(), Error> {
+    fn download_release_entry(
+        &self,
+        _asset: &VelopackAsset,
+        _local_file: &str,
+        _progress_sender: Option<Sender<i16>>,
+    ) -> Result<(), Error> {
         Err(Error::Generic("None source does not support downloads".to_owned()))
     }
     fn clone_boxed(&self) -> Box<dyn UpdateSource> {
@@ -51,11 +56,8 @@ pub struct AutoSource {
 impl AutoSource {
     /// Create a new AutoSource with the specified input string.
     pub fn new(input: &str) -> AutoSource {
-        let source: Box<dyn UpdateSource> = if Self::is_http_url(input) {
-            Box::new(HttpSource::new(input))
-        } else {
-            Box::new(FileSource::new(input))
-        };
+        let source: Box<dyn UpdateSource> =
+            if Self::is_http_url(input) { Box::new(HttpSource::new(input)) } else { Box::new(FileSource::new(input)) };
         AutoSource { source }
     }
 
@@ -166,6 +168,191 @@ impl UpdateSource for FileSource {
         if let Some(progress_sender) = &progress_sender {
             let _ = progress_sender.send(100);
         }
+        Ok(())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn UpdateSource> {
+        Box::new(self.clone())
+    }
+}
+
+/// Retrieves available releases from a GitHub repository.
+#[derive(Clone)]
+pub struct GithubSource {
+    /// The URL of the GitHub repository to download releases from
+    /// (e.g. https://github.com/myuser/myrepo)
+    repo_url: String,
+    /// The GitHub access token to use with the request to download releases.
+    /// If left empty, the GitHub rate limit for unauthenticated requests allows
+    /// for up to 60 requests per hour, limited by IP address.
+    access_token: Option<String>,
+    /// If true, pre-releases will be also be searched / downloaded. If false, only
+    /// stable releases will be considered.
+    prerelease: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    name: Option<String>,
+    prerelease: bool,
+    published_at: Option<String>,
+    assets: Vec<GithubReleaseAsset>,
+}
+
+#[derive(serde::Deserialize)]
+struct GithubReleaseAsset {
+    url: Option<String>,
+    browser_download_url: Option<String>,
+    name: Option<String>,
+}
+
+impl GithubSource {
+    /// Create a new GithubSource with the specified repository URL and optional access token.
+    pub fn new(repo_url: &str, access_token: Option<String>, prerelease: bool) -> GithubSource {
+        GithubSource { repo_url: repo_url.trim_end_matches('/').to_owned(), access_token, prerelease }
+    }
+
+    fn get_api_base_url(&self, repo_url: &url::Url) -> Result<url::Url, Error> {
+        if repo_url.host_str().map(|h| h.ends_with("github.com")).unwrap_or(false) {
+            Ok(url::Url::parse("https://api.github.com/")?)
+        } else {
+            // if it's not github.com, it's probably an Enterprise server
+            // now the problem with Enterprise is that the API doesn't come prefixed
+            // it comes suffixed so the API path of http://internal.github.server.local
+            // API location is http://internal.github.server.local/api/v3
+            let base = format!("{}://{}/api/v3/", repo_url.scheme(), repo_url.host_str().unwrap_or(""));
+            Ok(url::Url::parse(&base)?)
+        }
+    }
+
+    fn get_authorization(&self) -> Vec<(&str, String)> {
+        let mut headers = Vec::new();
+        if let Some(token) = &self.access_token {
+            headers.push(("Authorization", format!("token {}", token)));
+        }
+        headers
+    }
+
+    fn get_releases(&self, include_prereleases: bool) -> Result<Vec<GithubRelease>, Error> {
+        // https://docs.github.com/en/rest/reference/releases
+        const PER_PAGE: u32 = 100;
+        const PAGE: u32 = 1;
+        let repo_url = url::Url::parse(&self.repo_url)?;
+        let base_uri = self.get_api_base_url(&repo_url)?;
+        let releases_path = format!("repos{}/releases?per_page={}&page={}", repo_url.path(), PER_PAGE, PAGE);
+        let get_releases_uri = base_uri.join(&releases_path)?;
+
+        info!("Querying GitHub releases: {}", get_releases_uri);
+        let auth_headers = self.get_authorization();
+        let headers: Vec<(&str, &str)> =
+            auth_headers.iter().map(|(k, v)| (*k, v.as_str())).chain(vec![("User-Agent", "velopack-updater-rust")]).collect();
+
+        let response = download::download_url_as_string_with_headers(get_releases_uri.as_str(), &headers)?;
+        let mut releases: Vec<GithubRelease> = serde_json::from_str(&response)?;
+
+        // Sort by published_at descending and filter prereleases
+        releases.sort_by(|a, b| {
+            let a_date = a.published_at.as_deref().unwrap_or("");
+            let b_date = b.published_at.as_deref().unwrap_or("");
+            b_date.cmp(a_date)
+        });
+
+        if include_prereleases {
+            Ok(releases)
+        } else {
+            Ok(releases.into_iter().filter(|r| !r.prerelease).collect())
+        }
+    }
+
+    fn get_asset_url_from_name(&self, release: &GithubRelease, asset_name: &str) -> Result<String, Error> {
+        if release.assets.is_empty() {
+            return Err(Error::Generic(format!("No assets found in GitHub Release '{}'.", release.name.as_deref().unwrap_or(""))));
+        }
+
+        let matching_assets: Vec<&GithubReleaseAsset> =
+            release.assets.iter().filter(|a| a.name.as_deref().map(|n| n.eq_ignore_ascii_case(asset_name)).unwrap_or(false)).collect();
+
+        if matching_assets.is_empty() {
+            return Err(Error::Generic(format!(
+                "Could not find asset called '{}' in GitHub Release '{}'.",
+                asset_name,
+                release.name.as_deref().unwrap_or("")
+            )));
+        }
+
+        let asset = matching_assets[0];
+
+        if self.access_token.as_deref().map(|s| s.is_empty()).unwrap_or(true) {
+            // if no access_token provided, we use the browser_download_url which does not
+            // count towards the "unauthenticated api request" limit of 60 per hour per IP.
+            if let Some(browser_url) = &asset.browser_download_url {
+                return Ok(browser_url.clone());
+            }
+        }
+
+        if let Some(url) = &asset.url {
+            // otherwise, we use the regular asset url, which will allow us to retrieve
+            // assets from private repositories
+            // https://docs.github.com/en/rest/reference/releases#get-a-release-asset
+            return Ok(url.clone());
+        }
+
+        Err(Error::Generic("Could not find a valid asset url for the specified asset.".to_string()))
+    }
+}
+
+impl UpdateSource for GithubSource {
+    fn get_release_feed(&self, channel: &str, _app: &bundle::Manifest, _staged_user_id: &str) -> Result<VelopackAssetFeed, Error> {
+        let releases_filename = format!("releases.{}.json", channel);
+        let include_prereleases = self.prerelease;
+        let releases = self.get_releases(include_prereleases)?;
+        let mut all_assets: Vec<VelopackAsset> = Vec::new();
+
+        for r in releases.into_iter().filter(|r| include_prereleases || !r.prerelease) {
+            let Some(asset_url) = self.get_asset_url_from_name(&r, &releases_filename).ok() else { continue };
+            info!("Downloading GitHub feed asset '{}' from: {}", releases_filename, asset_url);
+            let auth_headers = self.get_authorization();
+            let headers: Vec<(&str, &str)> = auth_headers
+                .iter()
+                .map(|(k, v)| (*k, v.as_str()))
+                .chain(vec![("User-Agent", "velopack-updater-rust"), ("Accept", "application/vnd.github.v3+json")])
+                .collect();
+            let response = download::download_url_as_string_with_headers(&asset_url, &headers)?;
+            let feed: VelopackAssetFeed = serde_json::from_str(&response)?;
+            all_assets.extend(feed.Assets.into_iter());
+        }
+
+        Ok(VelopackAssetFeed { Assets: all_assets })
+    }
+
+    fn download_release_entry(&self, asset: &VelopackAsset, local_file: &str, progress_sender: Option<Sender<i16>>) -> Result<(), Error> {
+        let releases = self.get_releases(self.prerelease)?;
+
+        let mut download_url: Option<String> = None;
+        for r in releases {
+            if let Ok(url) = self.get_asset_url_from_name(&r, &asset.FileName) {
+                download_url = Some(url);
+                break;
+            }
+        }
+
+        let Some(url) = download_url else {
+            return Err(Error::Generic(format!("Could not find asset '{}' in any GitHub release.", asset.FileName)));
+        };
+
+        info!("About to download from URL '{}' to file '{}'", url, local_file);
+        let auth_headers = self.get_authorization();
+        let headers: Vec<(&str, &str)> = auth_headers
+            .iter()
+            .map(|(k, v)| (*k, v.as_str()))
+            .chain(vec![("User-Agent", "velopack-updater-rust"), ("Accept", "application/octet-stream")])
+            .collect();
+
+        download::download_url_to_file_with_headers(&url, local_file, &headers, move |p| {
+            if let Some(progress_sender) = &progress_sender {
+                let _ = progress_sender.send(p);
+            }
+        })?;
         Ok(())
     }
 

--- a/src/lib-rust/src/sources.rs
+++ b/src/lib-rust/src/sources.rs
@@ -228,7 +228,7 @@ impl GithubSource {
     fn get_authorization(&self) -> Vec<(&str, String)> {
         let mut headers = Vec::new();
         if let Some(token) = &self.access_token {
-            headers.push(("Authorization", format!("token {}", token)));
+            headers.push(("Authorization", format!("Bearer {}", token)));
         }
         headers
     }


### PR DESCRIPTION
Implement the `GithubSource` in the same way as the C# SDK writes.

related: #254 