### PR TITLE
Fix: Exclude packages without channel metadata from channel-specific feed requests

### DIFF
--- a/src/lib-csharp/Sources/SimpleFileSource.cs
+++ b/src/lib-csharp/Sources/SimpleFileSource.cs
@@ -50,12 +50,15 @@ namespace Velopack.Sources
                         var zip = new ZipPackage(pkg);
                         var asset = VelopackAsset.FromZipPackage(zip);
                         if (asset?.Version != null) {
-                            if (channel == null || zip?.Channel == null || zip?.Channel == channel) {
-                                logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
-                                list.Add(asset);
-                            } else {
+                            // If requesting a specific channel, only include packages explicitly in that channel
+                            if (channel != null && (zip?.Channel == null || zip?.Channel != channel)) {
                                 logger.Warn($"Skipping local package '{pkg}' because it is not in the '{channel}' channel.");
+                                continue;
                             }
+                            
+                            // If no specific channel requested (channel == null), include all packages
+                            logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
+                            list.Add(asset);
                         }
                     } catch (Exception ex) {
                         logger.Warn(ex, $"Error while reading local package '{pkg}'.");


### PR DESCRIPTION
### Summary
Fixes an issue where packages without channel metadata (`zip.Channel == null`) are incorrectly included in channel-specific feed requests. This primarily affects migration scenarios from Clowd.Squirrel where legacy packages lack channel information.

### Problem
The current logic in `SimpleFileSource.GetReleaseFeed()` treats packages without channel metadata as matching any channel:
```csharp
if (channel == null || zip?.Channel == null || zip?.Channel == channel) {
    list.Add(asset);
}
```

This means when requesting updates for a specific channel (e.g., "beta"), legacy packages without channel metadata are incorrectly included in the results, potentially causing:
- Incorrect version detection (e.g., 3.0.111 legacy package appearing in beta feed)
- Unintended downgrades when `AllowVersionDowngrade = true`
- Confusion during Squirrel → Velopack migrations

### Solution
Changed the logic to only include packages with explicit channel matches when a specific channel is requested:
```csharp
// If requesting a specific channel, only include packages explicitly in that channel
if (channel != null && (zip?.Channel == null || zip?.Channel != channel)) {
    logger.Warn($"Skipping local package '{pkg}' because it is not in the '{channel}' channel.");
    continue;
}

// If no specific channel requested (channel == null), include all packages
logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
list.Add(asset);
```

### Testing
Have not tested locally, but the logic is pretty straightforward.

### Breaking Changes
Not sure if there is any background as to why this exists the way it does, would have to have a more active maintainer chime in on any breaking changes.