### PR TITLE
Resolves wxPython build issues on macOS

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           pip install uv
         if: ${{ matrix.sample == 'PythonWXPython' }}
+      - name: Install wxPython
+        working-directory: samples/${{ matrix.sample }}
+        run: |
+          pip install -U wxPython
+        if: ${{ matrix.sample == 'PythonWXPython' && matrix.os == 'macos-latest' }}
       - name: Refresh uv.lock for wxPython
         working-directory: samples/${{ matrix.sample }}
         run: |

--- a/samples/PythonWXPython/pyproject.toml
+++ b/samples/PythonWXPython/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "velopack",
-    "wxpython>=4.2.3",
+    "wxpython>=4.2.4",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
The `PythonWXPython` sample build was encountering issues on macOS, specifically related to a `libpng` dependency with `wxPython`. This change addresses the problem by:

*   Updating the `wxPython` dependency to version `4.2.4` in the `pyproject.toml` file.
*   Introducing an explicit installation step for `wxPython` using `pip` in the GitHub Actions workflow for macOS builds. This ensures `wxPython` is properly installed before other dependency management steps, preventing the `libpng` dependency conflict.

This resolves the previous build failures for the `PythonWXPython` sample on macOS.