### PR TITLE
Updates macOS runner to macos-15

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/src/lib-rust/src/download.rs
+++ b/src/lib-rust/src/download.rs
@@ -67,7 +67,8 @@ fn test_download_uses_tls_and_encoding_correctly() {
 #[test]
 fn test_download_file_reports_progress() {
     // https://www.ip-toolbox.com/speedtest-files/
-    let test_file = "https://proof.ovh.net/files/10Mb.dat";
+    //"https://proof.ovh.net/files/10Mb.dat"
+    let test_file = "https://velopacktesting.blob.core.windows.net/ci-test-files/10Mb.dat";
     let mut prog_count = 0;
     let mut last_prog = 0;
 


### PR DESCRIPTION
Updates the GitHub Actions macOS runner for `x86_64` builds from `macos-13` to `macos-15`. This keeps the continuous integration environment current with a newer macOS version.