### PR TITLE
Fix file signing with spaces in Linux

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
+++ b/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
@@ -84,7 +84,12 @@ public class CodeSign
                 filesToSign.Add(pendingSign.Dequeue());
             }
 
-            var filesToSignStr = String.Join(" ", filesToSign.Select(f => $"\"{f}\""));
+            string filesToSignStr;
+            if (VelopackRuntimeInfo.IsWindows) {
+                filesToSignStr = String.Join(" ", filesToSign.Select(f => $"\"{f}\""));
+            } else {
+                filesToSignStr = String.Join(" ", filesToSign.Select(f => $"'{f}'"));
+            }
 
             string command;
             if (signAsTemplate) {

--- a/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
+++ b/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
@@ -88,7 +88,9 @@ public class CodeSign
             if (VelopackRuntimeInfo.IsWindows) {
                 filesToSignStr = String.Join(" ", filesToSign.Select(f => $"\"{f}\""));
             } else {
+                // For Linux: use single quotes and escape special characters for bash
                 filesToSignStr = String.Join(" ", filesToSign.Select(f => $"'{f}'"));
+                signArguments = EscapeForBash(signArguments);
             }
 
             string command;
@@ -123,8 +125,7 @@ public class CodeSign
 
         if (!VelopackRuntimeInfo.IsWindows) {
             fileName = "/bin/bash";
-            string escapedCommand = command.Replace("'", "'\\''");
-            args = $"-c \"{escapedCommand} >> \\\"{signLogFile}\\\" 2>&1\"";
+            args = $"-c \"{command} >> \\\"{signLogFile}\\\" 2>&1\"";
         }
 
         var psi = new ProcessStartInfo {
@@ -145,5 +146,14 @@ public class CodeSign
                 $"Signing command failed. Specify --verbose argument to print signing command." + Environment.NewLine +
                 $"Output was:" + Environment.NewLine + output);
         }
+    }
+
+    private string EscapeForBash(string filePath)
+    {
+        return filePath.Replace("$", "\\$")
+                       .Replace("`", "\\`")
+                       .Replace("\"", "\\\"")
+                       .Replace("'", "\\'")
+                       .Replace("\\", "\\\\");
     }
 }


### PR DESCRIPTION
When signing on Linux with a files with spaces in them will fail to sign.
The output:
```
[01:04:28 INF] Code-signed 118/171 files
[01:04:29 INF] Code-signed 119/171 files
jsign: The file /tmp/velopack/temp.1/PreprocessPackDirWin/Bus couldn't be found
```

Verbose output:
```
[01:55:53 DBG] Signing command failed - 
    /bin/bash -c "java -jar /workspace/local/monitor/jsign.jar --storetype TRUSTEDSIGNING --keystore https://weu.codesigning.azure.net --storepass <key removed> --alias Fischer/remco "/tmp/velopack/temp.1/PreprocessPackDirWin/PcanView.exe" "/tmp/velopack/temp.1/PreprocessPackDirWin/Bus Monitor.exe" "/tmp/velopack/temp.1/PreprocessPackDirWin/Squirrel.exe" "/tmp/velopack/temp.1/PreprocessPackDirWin/Bus Monitor_ExecutionStub.exe" >> \"/tmp/velopack/temp.2\" 2>&1"
```