### PR TITLE
OSX: Sign UpdateMac with default entitlements when --signDisableDeep is enabled

### DIFF
--- a/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackCommandRunner.cs
@@ -100,7 +100,7 @@ public class OsxPackCommandRunner : PackageBuilder<OsxPackOptions>
                 Log.Info("Code signing Velopack binaries...");
                 var structure = new OsxStructureBuilder(packDir);
                 var updateMacPath = Path.Combine(structure.MacosDirectory, "UpdateMac");
-                helper.CodeSign(Options.SignAppIdentity, entitlements, updateMacPath, false, keychainPath);
+                helper.CodeSign(Options.SignAppIdentity, HelperFile.VelopackEntitlements, updateMacPath, false, keychainPath);
                 signProgress(50);
                 
                 Log.Info("Code signing application bundle...");


### PR DESCRIPTION
When signing with certain entitlements which require a provisioning profile, UpdateMac is signed with the same entitlements causing it to be unable to execute.
This change only applies to `--signDisableDeep` as a provisioning profile likely isn't to be used without it

Fixes #769 