### PR TITLE
fixed splash image dpi issue (blurriness) when windows has custom scaling applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,12 +686,9 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
 dependencies = [
- "bytemuck",
  "cfg-if 1.0.4",
  "document-features",
- "image",
  "num-traits",
- "rayon",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,23 @@ checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as-slice"
@@ -116,16 +148,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -144,6 +234,12 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -226,7 +322,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -358,6 +454,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -502,6 +604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +630,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +663,36 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fast_image_resize"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+dependencies = [
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "document-features",
+ "image",
+ "num-traits",
+ "rayon",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -684,7 +845,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -704,6 +865,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -898,13 +1070,22 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "exr",
  "gif",
  "moxcms",
  "num-traits",
  "png",
+ "ravif",
+ "rayon",
  "zune-core",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -919,10 +1100,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -973,10 +1174,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -1040,6 +1257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1296,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if 1.0.4",
+ "rayon",
 ]
 
 [[package]]
@@ -1139,6 +1381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1409,30 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normpath"
@@ -1205,10 +1477,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1439,6 +1752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty-bytes-rust"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1869,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1620,6 +1973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,13 +2001,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1656,6 +2044,56 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if 1.0.4",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
 
 [[package]]
 name = "rayon"
@@ -1739,6 +2177,12 @@ dependencies = [
  "normpath",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -1979,6 +2423,15 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "simple-stopwatch"
@@ -2378,7 +2831,18 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand",
+ "rand 0.10.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -2395,7 +2859,7 @@ dependencies = [
  "log",
  "log-panics",
  "normpath",
- "rand",
+ "rand 0.10.0",
  "regex",
  "semver",
  "serde",
@@ -2429,6 +2893,7 @@ dependencies = [
  "derivative",
  "dialog",
  "enum-flags",
+ "fast_image_resize",
  "fs_extra",
  "glob",
  "image",
@@ -2444,7 +2909,7 @@ dependencies = [
  "pretty-bytes-rust",
  "pretty_assertions",
  "progress-streams",
- "rand",
+ "rand 0.10.0",
  "rayon",
  "regex",
  "remove_dir_all",
@@ -3065,6 +3530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3562,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3224,6 +3715,15 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ libloading = "0.9"
 strsim = "0.11"
 same-file = "1.0"
 filelocksmith = "0.1"
-fast_image_resize = { version = "6.0", features = ["rayon"] }
+fast_image_resize = "6.0"
 image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "rayon"] }
 fs_extra = "1.3"
 memmap2 = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,8 @@ libloading = "0.9"
 strsim = "0.11"
 same-file = "1.0"
 filelocksmith = "0.1"
-image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png"] }
+fast_image_resize = { version = "6.0", features = ["rayon"] }
+image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "rayon"] }
 fs_extra = "1.3"
 memmap2 = "0.9"
 windows = "0.62"

--- a/src/bins/Cargo.toml
+++ b/src/bins/Cargo.toml
@@ -82,6 +82,7 @@ waitpid-any.workspace = true
 [target.'cfg(windows)'.dependencies]
 fs_extra.workspace = true
 memmap2.workspace = true
+fast_image_resize.workspace = true
 image.workspace = true
 windows = { workspace = true, features = [
     "Win32_Foundation",

--- a/src/bins/src/windows/splash.rs
+++ b/src/bins/src/windows/splash.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use image::{codecs::gif::GifDecoder, AnimationDecoder, DynamicImage, ImageFormat, ImageReader};
+use image::{codecs::gif::GifDecoder, imageops::FilterType, AnimationDecoder, DynamicImage, ImageFormat, ImageReader};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{io::Cursor, thread};
 use velopack::wide_strings::string_to_wide;
@@ -82,8 +82,8 @@ struct SplashWindow {
     rx: Receiver<i16>,
     progress: i16,
     frame_idx: usize,
-    w: i32,         // original bitmap width
-    h: i32,         // original bitmap height
+    w: i32,         // current bitmap width (pre-scaled to match window)
+    h: i32,         // current bitmap height (pre-scaled to match window)
     scaled_w: i32,  // DPI-scaled window width
     scaled_h: i32,  // DPI-scaled window height
     dpi_scale: f32, // current DPI scale factor
@@ -194,7 +194,7 @@ const ALPHA_BLEND_FN: BLENDFUNCTION = BLENDFUNCTION {
 impl SplashWindow {
     pub unsafe fn run(app_name: String, img_stream: Vec<u8>, rx: Receiver<i16>, progress_bar_color: Option<(u8, u8, u8)>) -> Result<()> {
         let mut delays = Vec::new();
-        let mut frames = Vec::new();
+        let mut decoded_images = Vec::new();
 
         let fmt_cursor = Cursor::new(&img_stream);
         let fmt_reader = ImageReader::new(fmt_cursor).with_guessed_format()?;
@@ -213,21 +213,15 @@ impl SplashWindow {
                 let (num, dem) = frame.delay().numer_denom_ms();
                 delays.push((num / dem) as u32);
                 let dynamic = DynamicImage::from(frame.buffer().to_owned());
-                let mut vec = dynamic.to_rgba8().to_vec();
-                convert_rgba_to_bgra(&mut vec);
-                let bitmap = CreateBitmap(w, h, 1, 32, Some(vec.as_mut_ptr() as *mut _));
-                frames.push(bitmap);
+                decoded_images.push(dynamic);
             }
-            info!("Successfully loaded {} frames.", frames.len());
+            info!("Successfully loaded {} frames.", decoded_images.len());
         } else {
             info!("Loading static image (detected {:?})...", fmt);
             delays.push(16u32); // 60 fps
             let img_cursor = Cursor::new(&img_stream);
             let img_decoder = ImageReader::new(img_cursor).with_guessed_format()?.decode()?;
-            let mut vec = img_decoder.to_rgba8().to_vec();
-            convert_rgba_to_bgra(&mut vec);
-            let bitmap = CreateBitmap(w, h, 1, 32, Some(vec.as_mut_ptr() as *mut _));
-            frames.push(bitmap);
+            decoded_images.push(img_decoder);
             info!("Successfully loaded.");
         }
 
@@ -268,6 +262,21 @@ impl SplashWindow {
             (cw, ch)
         };
         info!("DPI scale: {}, window size: {}x{} -> {}x{}", dpi_scale, w, h, scaled_w, scaled_h);
+
+        // Pre-scale frames using high-quality Lanczos3 resampling so the bitmaps
+        // match the window size. This avoids blurry GDI stretching at high DPI.
+        let mut frames = Vec::new();
+        for img in &decoded_images {
+            let scaled_img = if scaled_w != w || scaled_h != h {
+                img.resize_exact(scaled_w as u32, scaled_h as u32, FilterType::Lanczos3)
+            } else {
+                img.clone()
+            };
+            let mut vec = scaled_img.to_rgba8().into_vec();
+            convert_rgba_to_bgra(&mut vec);
+            let bitmap = CreateBitmap(scaled_w, scaled_h, 1, 32, Some(vec.as_mut_ptr() as *mut _));
+            frames.push(bitmap);
+        }
 
         let class_name = string_to_wide("VelopackSetupSplashWindow");
         let app_name = string_to_wide(&app_name);
@@ -316,8 +325,8 @@ impl SplashWindow {
             frames,
             rx,
             frame_idx: 0,
-            w,
-            h,
+            w: scaled_w,
+            h: scaled_h,
             scaled_w,
             scaled_h,
             dpi_scale,

--- a/src/bins/src/windows/splash.rs
+++ b/src/bins/src/windows/splash.rs
@@ -79,6 +79,33 @@ pub fn show_splash_dialog(app_name: String, imgstream: Option<Vec<u8>>, options:
     tx
 }
 
+struct ProgressBar {
+    hdc: OwnedCompatibleDC,
+    _bmp: OwnedBitmap,
+}
+
+impl ProgressBar {
+    fn new(color: (u8, u8, u8), screen: &OwnedDC) -> Self {
+        let (r, g, b) = color;
+        let pixel: u32 = (255u32 << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
+        let pixel_bytes = pixel.to_ne_bytes();
+        let bmp = OwnedBitmap::from_bgra8_pixels(1, 1, &pixel_bytes);
+        let hdc = OwnedCompatibleDC::new(screen);
+        unsafe { SelectObject(hdc.0, bmp.0.into()) };
+        Self { hdc, _bmp: bmp }
+    }
+
+    fn draw(&self, dest: &OwnedCompatibleDC, scaled_w: i32, scaled_h: i32, dpi_scale: f32, progress: i16) {
+        let progress_width = (scaled_w as f32 * (progress as f32 / 100.0)) as i32;
+        let progress_height = (12.0 * dpi_scale) as i32;
+        if progress_width > 0 {
+            unsafe {
+                let _ = StretchBlt(dest.0, 0, scaled_h - progress_height, progress_width, progress_height, Some(self.hdc.0), 0, 0, 1, 1, SRCCOPY);
+            }
+        }
+    }
+}
+
 struct SplashWindow {
     frames: Vec<OwnedBitmap>,
     decoded_images: Vec<Vec<u8>>,
@@ -90,8 +117,11 @@ struct SplashWindow {
     scaled_w: i32,
     scaled_h: i32,
     dpi_scale: f32,
-    hdc_screen: HDC,
-    progress_bar_color: Option<(u8, u8, u8)>,
+    hdc_screen: OwnedDC,
+    hdc_src: OwnedCompatibleDC,
+    hdc_mem: OwnedCompatibleDC,
+    bmp_mem: OwnedBitmap,
+    bar: Option<ProgressBar>,
 }
 
 fn average(numbers: &[u32]) -> u32 {
@@ -170,7 +200,7 @@ fn clamp_to_monitor(scaled_w: i32, scaled_h: i32, monitor_rect: &RECT) -> (i32, 
 
 // Lanczos3 ringing can produce pixels where RGB > A (invalid premultiplied state),
 // which appear as bright garbage pixels at alpha edges.
-// LLVM auto-vectorizes this to SSE4.1 pminud, processing 8 pixels per iteration.
+// LLVM auto-vectorizes this to SSE2 or SSE4.1 pminud, depending on compiler flags.
 // https://rust.godbolt.org/z/W7jPEsxTz
 fn clamp_premultiplied(pixels: &mut [u8]) {
     for chunk in pixels.chunks_exact_mut(4) {
@@ -186,7 +216,7 @@ fn clamp_premultiplied(pixels: &mut [u8]) {
 // Swaps R/B channels and premultiplies RGB by alpha in a single pass using SWAR
 // (SIMD Within A Register). Processes R+B in parallel within a u32 by exploiting
 // the fact that their products (max 255*256) can't overflow 16-bit lanes.
-// LLVM auto-vectorizes this to SSE4.1 (pshufb + pmulld), processing 4 pixels per iteration.
+// LLVM auto-vectorizes this to SSE2 or SSE4.1 (pshufb + pmulld), depending on compiler flags.
 // UpdateLayeredWindow with AC_SRC_ALPHA expects premultiplied BGRA.
 // See: https://users.rust-lang.org/t/the-fastest-way-to-copy-a-buffer-bgra-to-rgba/126651
 // https://rust.godbolt.org/z/W7jPEsxTz
@@ -218,6 +248,12 @@ fn rgb(red: u8, green: u8, blue: u8) -> COLORREF {
 struct OwnedBitmap(HBITMAP);
 unsafe impl Send for OwnedBitmap {}
 
+impl OwnedBitmap {
+    fn from_bgra8_pixels(w: i32, h: i32, pixels: &[u8]) -> Self {
+        Self(unsafe { CreateBitmap(w, h, 1, 32, Some(pixels.as_ptr() as *const _)) })
+    }
+}
+
 impl Drop for OwnedBitmap {
     fn drop(&mut self) {
         unsafe {
@@ -226,29 +262,96 @@ impl Drop for OwnedBitmap {
     }
 }
 
+struct OwnedDC {
+    hdc: HDC,
+    hwnd: HWND,
+}
+
+impl OwnedDC {
+    fn from_desktop() -> Self {
+        unsafe {
+            let hwnd = GetDesktopWindow();
+            Self { hdc: GetDC(Some(hwnd)), hwnd }
+        }
+    }
+}
+
+impl Drop for OwnedDC {
+    fn drop(&mut self) {
+        unsafe { ReleaseDC(Some(self.hwnd), self.hdc) };
+    }
+}
+
+struct BitmapGuard {
+    hdc: HDC,
+    old: HGDIOBJ,
+}
+
+impl Drop for BitmapGuard {
+    fn drop(&mut self) {
+        unsafe { SelectObject(self.hdc, self.old) };
+    }
+}
+
+struct OwnedCompatibleDC(HDC);
+
+impl OwnedCompatibleDC {
+    fn new(screen: &OwnedDC) -> Self {
+        Self(unsafe { CreateCompatibleDC(Some(screen.hdc)) })
+    }
+
+    fn hdc(&self) -> HDC {
+        self.0
+    }
+
+    fn use_bitmap(&self, bmp: HBITMAP) -> BitmapGuard {
+        let old = unsafe { SelectObject(self.0, bmp.into()) };
+        BitmapGuard { hdc: self.0, old }
+    }
+
+    fn blit_from(&self, src: &Self, w: i32, h: i32) {
+        unsafe {
+            let _ = BitBlt(self.0, 0, 0, w, h, Some(src.0), 0, 0, SRCCOPY);
+        }
+    }
+
+    fn create_surface(&self, screen: &OwnedDC, w: i32, h: i32) -> OwnedBitmap {
+        unsafe {
+            let bmp = CreateCompatibleBitmap(screen.hdc, w, h);
+            SelectObject(self.0, bmp.into());
+            OwnedBitmap(bmp)
+        }
+    }
+}
+
+impl Drop for OwnedCompatibleDC {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DeleteDC(self.0);
+        }
+    }
+}
+
 fn scale_frames(images: &[Vec<u8>], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec<OwnedBitmap> {
     let need_scale = src_w != dst_w || src_h != dst_h;
+    let resize_opts = fr::ResizeOptions::new().resize_alg(fr::ResizeAlg::Convolution(fr::FilterType::Lanczos3));
+    let (dw, dh) = (dst_w as i32, dst_h as i32);
     images
         .par_iter()
-        .map(|bgra| {
-            if need_scale {
-                let src_image = fr::images::ImageRef::new(src_w, src_h, bgra, fr::PixelType::U8x4).unwrap();
-                let mut dst_image = fr::images::Image::new(dst_w, dst_h, fr::PixelType::U8x4);
-                let mut resizer = fr::Resizer::new();
-                resizer
-                    .resize(
-                        &src_image,
-                        &mut dst_image,
-                        &fr::ResizeOptions::new().resize_alg(fr::ResizeAlg::Convolution(fr::FilterType::Lanczos3)),
-                    )
-                    .unwrap();
-                let mut vec = dst_image.into_vec();
-                clamp_premultiplied(&mut vec);
-                OwnedBitmap(unsafe { CreateBitmap(dst_w as i32, dst_h as i32, 1, 32, Some(vec.as_mut_ptr() as *mut _)) })
-            } else {
-                OwnedBitmap(unsafe { CreateBitmap(dst_w as i32, dst_h as i32, 1, 32, Some(bgra.as_ptr() as *const _)) })
-            }
-        })
+        .map_init(
+            || (fr::Resizer::new(), fr::images::Image::new(dst_w, dst_h, fr::PixelType::U8x4)),
+            |(resizer, dst_image), bgra| {
+                if need_scale {
+                    let src_image = fr::images::ImageRef::new(src_w, src_h, bgra, fr::PixelType::U8x4).unwrap();
+                    resizer.resize(&src_image, dst_image, &resize_opts).unwrap();
+                    let buf = dst_image.buffer_mut();
+                    clamp_premultiplied(buf);
+                    OwnedBitmap::from_bgra8_pixels(dw, dh, buf)
+                } else {
+                    OwnedBitmap::from_bgra8_pixels(dw, dh, bgra)
+                }
+            },
+        )
         .collect()
 }
 
@@ -374,8 +477,11 @@ impl SplashWindow {
             None,
         )?;
 
-        let hwnd_desktop = unsafe { GetDesktopWindow() };
-        let hdc_screen = unsafe { GetDC(Some(hwnd_desktop)) };
+        let hdc_screen = OwnedDC::from_desktop();
+        let hdc_src = OwnedCompatibleDC::new(&hdc_screen);
+        let hdc_mem = OwnedCompatibleDC::new(&hdc_screen);
+        let bmp_mem = hdc_mem.create_surface(&hdc_screen, scaled_w, scaled_h);
+        let bar = progress_bar_color.map(|c| ProgressBar::new(c, &hdc_screen));
 
         let data_ptr = Box::into_raw(Box::new(Self {
             frames,
@@ -389,7 +495,10 @@ impl SplashWindow {
             dpi_scale,
             progress: 0,
             hdc_screen,
-            progress_bar_color,
+            hdc_src,
+            hdc_mem,
+            bmp_mem,
+            bar,
         }));
 
         SetWindowLongPtrW(hwnd, GWL_USERDATA, (data_ptr as isize).try_into()?);
@@ -407,9 +516,7 @@ impl SplashWindow {
             DispatchMessageW(&msg);
         }
 
-        let data = Box::from_raw(data_ptr);
-        ReleaseDC(Some(hwnd_desktop), data.hdc_screen);
-        drop(data);
+        drop(Box::from_raw(data_ptr));
 
         let _ = DestroyWindow(hwnd);
         Ok(())
@@ -428,6 +535,8 @@ impl SplashWindow {
 
                 self.frames = scale_frames(&self.decoded_images, self.orig_w, self.orig_h, self.scaled_w as u32, self.scaled_h as u32);
                 self.frame_idx = 0;
+
+                self.bmp_mem = self.hdc_mem.create_surface(&self.hdc_screen, self.scaled_w, self.scaled_h);
 
                 let _ = SetWindowPos(
                     hwnd,
@@ -470,90 +579,27 @@ impl SplashWindow {
                     return 0;
                 }
 
-                let h_bitmap = self.frames[self.frame_idx].0;
+                let _guard = self.hdc_src.use_bitmap(self.frames[self.frame_idx].0);
+                self.hdc_mem.blit_from(&self.hdc_src, self.scaled_w, self.scaled_h);
+                drop(_guard);
 
-                let hdc_src = CreateCompatibleDC(Some(self.hdc_screen));
-                let src_old = SelectObject(hdc_src, h_bitmap.into());
-
-                // create a scaled bitmap for the output
-                let hdc_dest = CreateCompatibleDC(Some(self.hdc_screen));
-                let scaled_bitmap = CreateCompatibleBitmap(self.hdc_screen, self.scaled_w, self.scaled_h);
-                let dest_old = SelectObject(hdc_dest, scaled_bitmap.into());
-
-                let result = AlphaBlend(
-                    hdc_dest,
-                    0,
-                    0,
-                    self.scaled_w,
-                    self.scaled_h,
-                    hdc_src,
-                    0,
-                    0,
-                    self.scaled_w,
-                    self.scaled_h,
-                    ALPHA_BLEND_FN,
-                );
-                if !result.as_bool() {
-                    warn!("AlphaBlend failed");
+                if let Some(bar) = &self.bar {
+                    bar.draw(&self.hdc_mem, self.scaled_w, self.scaled_h, self.dpi_scale, self.progress);
                 }
 
-                // draw progress bar on top of the scaled bitmap (if enabled)
-                // Must use AlphaBlend with a 32-bit BGRA bitmap so the alpha channel
-                // is set to 255 (opaque). FillRect leaves alpha at 0, which
-                // UpdateLayeredWindow treats as fully transparent.
-                if let Some((r, g, b)) = self.progress_bar_color {
-                    let progress_width = (self.scaled_w as f32 * (self.progress as f32 / 100.0)) as i32;
-                    let progress_height = (12.0 * self.dpi_scale) as i32;
-                    if progress_width > 0 {
-                        // BGRA pixel with alpha=255 (little-endian u32: 0xAARRGGBB)
-                        let pixel: u32 = (255u32 << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-                        let mut pixel_data = [pixel];
-                        let bar_bmp = CreateBitmap(1, 1, 1, 32, Some(pixel_data.as_mut_ptr() as *mut _));
-                        let hdc_bar = CreateCompatibleDC(Some(self.hdc_screen));
-                        let old_bar = SelectObject(hdc_bar, bar_bmp.into());
-                        let _ = AlphaBlend(
-                            hdc_dest,
-                            0,
-                            self.scaled_h - progress_height,
-                            progress_width,
-                            progress_height,
-                            hdc_bar,
-                            0,
-                            0,
-                            1,
-                            1,
-                            ALPHA_BLEND_FN,
-                        );
-                        SelectObject(hdc_bar, old_bar);
-                        let _ = DeleteDC(hdc_bar);
-                        let _ = DeleteObject(bar_bmp.into());
-                    }
-                }
-
-                // Use UpdateLayeredWindow for true transparency with per-pixel alpha
-                let size = SIZE {
-                    cx: self.scaled_w,
-                    cy: self.scaled_h,
-                };
+                let size = SIZE { cx: self.scaled_w, cy: self.scaled_h };
                 let pt_src = POINT { x: 0, y: 0 };
                 let _ = UpdateLayeredWindow(
                     hwnd,
                     None,
                     None,
                     Some(&size),
-                    Some(hdc_dest),
+                    Some(self.hdc_mem.hdc()),
                     Some(&pt_src),
                     COLORREF(0),
                     Some(&ALPHA_BLEND_FN),
                     ULW_ALPHA,
                 );
-
-                // clean up
-                SelectObject(hdc_dest, dest_old);
-                SelectObject(hdc_src, src_old);
-                let _ = DeleteDC(hdc_dest);
-                let _ = DeleteDC(hdc_src);
-                let _ = DeleteObject(scaled_bitmap.into());
 
                 let _ = EndPaint(hwnd, &ps);
                 return 0;
@@ -676,17 +722,17 @@ fn test_parse_hex_color_invalid_falls_back_to_green() {
 fn show_splash_gif() {
     let rd = std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/splash-test.gif")).unwrap();
     let tx = show_splash_dialog("osu!".to_string(), Some(rd), SplashOptions::default());
+    let duration = std::time::Duration::from_secs(10);
+    let interval = std::time::Duration::from_millis(16);
+    let steps = (duration.as_millis() / interval.as_millis()) as i16;
+    for i in 1..=steps {
+        std::thread::sleep(interval);
+        let progress = (i as f32 / steps as f32 * 100.0) as i16;
+        let _ = tx.send(progress);
+    }
     std::thread::sleep(std::time::Duration::from_secs(1));
-    let _ = tx.send(25);
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    let _ = tx.send(50);
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    let _ = tx.send(75);
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    let _ = tx.send(100);
-    std::thread::sleep(std::time::Duration::from_secs(3));
     let _ = tx.send(MSG_CLOSE);
-    std::thread::sleep(std::time::Duration::from_secs(3));
+    std::thread::sleep(std::time::Duration::from_secs(1));
 }
 
 #[test]

--- a/src/bins/src/windows/splash.rs
+++ b/src/bins/src/windows/splash.rs
@@ -1,5 +1,7 @@
 use anyhow::{bail, Result};
-use image::{codecs::gif::GifDecoder, imageops::FilterType, AnimationDecoder, DynamicImage, ImageFormat, ImageReader};
+use fast_image_resize as fr;
+use image::{codecs::gif::GifDecoder, AnimationDecoder, ImageFormat, ImageReader};
+use rayon::prelude::*;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{io::Cursor, thread};
 use velopack::wide_strings::string_to_wide;
@@ -78,15 +80,16 @@ pub fn show_splash_dialog(app_name: String, imgstream: Option<Vec<u8>>, options:
 }
 
 struct SplashWindow {
-    frames: Vec<HBITMAP>,
+    frames: Vec<OwnedBitmap>,
+    decoded_images: Vec<Vec<u8>>,
+    orig_w: u32,
+    orig_h: u32,
     rx: Receiver<i16>,
     progress: i16,
     frame_idx: usize,
-    w: i32,         // current bitmap width (pre-scaled to match window)
-    h: i32,         // current bitmap height (pre-scaled to match window)
-    scaled_w: i32,  // DPI-scaled window width
-    scaled_h: i32,  // DPI-scaled window height
-    dpi_scale: f32, // current DPI scale factor
+    scaled_w: i32,
+    scaled_h: i32,
+    dpi_scale: f32,
     hdc_screen: HDC,
     progress_bar_color: Option<(u8, u8, u8)>,
 }
@@ -165,9 +168,37 @@ fn clamp_to_monitor(scaled_w: i32, scaled_h: i32, monitor_rect: &RECT) -> (i32, 
     }
 }
 
-fn convert_rgba_to_bgra(image_data: &mut [u8]) {
-    for chunk in image_data.chunks_mut(4) {
-        chunk.swap(0, 2);
+// Lanczos3 ringing can produce pixels where RGB > A (invalid premultiplied state),
+// which appear as bright garbage pixels at alpha edges.
+// LLVM auto-vectorizes this to SSE4.1 pminud, processing 8 pixels per iteration.
+// https://rust.godbolt.org/z/W7jPEsxTz
+fn clamp_premultiplied(pixels: &mut [u8]) {
+    for chunk in pixels.chunks_exact_mut(4) {
+        let p = u32::from_ne_bytes(chunk.try_into().unwrap());
+        let a = (p >> 24) & 0xFF;
+        let r = (p & 0xFF).min(a);
+        let g = ((p >> 8) & 0xFF).min(a);
+        let b = ((p >> 16) & 0xFF).min(a);
+        chunk.copy_from_slice(&(r | (g << 8) | (b << 16) | (a << 24)).to_ne_bytes());
+    }
+}
+
+// Swaps R/B channels and premultiplies RGB by alpha in a single pass using SWAR
+// (SIMD Within A Register). Processes R+B in parallel within a u32 by exploiting
+// the fact that their products (max 255*256) can't overflow 16-bit lanes.
+// LLVM auto-vectorizes this to SSE4.1 (pshufb + pmulld), processing 4 pixels per iteration.
+// UpdateLayeredWindow with AC_SRC_ALPHA expects premultiplied BGRA.
+// See: https://users.rust-lang.org/t/the-fastest-way-to-copy-a-buffer-bgra-to-rgba/126651
+// https://rust.godbolt.org/z/W7jPEsxTz
+fn convert_rgba_to_premultiplied_bgra(pixels: &mut [u8]) {
+    for chunk in pixels.chunks_exact_mut(4) {
+        let p = u32::from_ne_bytes(chunk.try_into().unwrap());
+        let a = p >> 24;
+        let a1 = a + 1;
+        let rb_swapped = (p >> 16 & 0xFF) | ((p & 0xFF) << 16);
+        let rb = (rb_swapped.wrapping_mul(a1) >> 8) & 0x00FF00FF;
+        let g = ((p & 0x0000FF00).wrapping_mul(a1) >> 8) & 0x0000FF00;
+        chunk.copy_from_slice(&(rb | g | (a << 24)).to_ne_bytes());
     }
 }
 
@@ -184,6 +215,43 @@ fn rgb(red: u8, green: u8, blue: u8) -> COLORREF {
     COLORREF((red as u32) | ((green as u32) << 8) | ((blue as u32) << 16))
 }
 
+struct OwnedBitmap(HBITMAP);
+unsafe impl Send for OwnedBitmap {}
+
+impl Drop for OwnedBitmap {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DeleteObject(self.0.into());
+        }
+    }
+}
+
+fn scale_frames(images: &[Vec<u8>], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec<OwnedBitmap> {
+    let need_scale = src_w != dst_w || src_h != dst_h;
+    images
+        .par_iter()
+        .map(|bgra| {
+            if need_scale {
+                let src_image = fr::images::ImageRef::new(src_w, src_h, bgra, fr::PixelType::U8x4).unwrap();
+                let mut dst_image = fr::images::Image::new(dst_w, dst_h, fr::PixelType::U8x4);
+                let mut resizer = fr::Resizer::new();
+                resizer
+                    .resize(
+                        &src_image,
+                        &mut dst_image,
+                        &fr::ResizeOptions::new().resize_alg(fr::ResizeAlg::Convolution(fr::FilterType::Lanczos3)),
+                    )
+                    .unwrap();
+                let mut vec = dst_image.into_vec();
+                clamp_premultiplied(&mut vec);
+                OwnedBitmap(unsafe { CreateBitmap(dst_w as i32, dst_h as i32, 1, 32, Some(vec.as_mut_ptr() as *mut _)) })
+            } else {
+                OwnedBitmap(unsafe { CreateBitmap(dst_w as i32, dst_h as i32, 1, 32, Some(bgra.as_ptr() as *const _)) })
+            }
+        })
+        .collect()
+}
+
 const ALPHA_BLEND_FN: BLENDFUNCTION = BLENDFUNCTION {
     BlendOp: AC_SRC_OVER as u8,
     BlendFlags: 0,
@@ -194,7 +262,7 @@ const ALPHA_BLEND_FN: BLENDFUNCTION = BLENDFUNCTION {
 impl SplashWindow {
     pub unsafe fn run(app_name: String, img_stream: Vec<u8>, rx: Receiver<i16>, progress_bar_color: Option<(u8, u8, u8)>) -> Result<()> {
         let mut delays = Vec::new();
-        let mut decoded_images = Vec::new();
+        let mut decoded_images: Vec<Vec<u8>> = Vec::new();
 
         let fmt_cursor = Cursor::new(&img_stream);
         let fmt_reader = ImageReader::new(fmt_cursor).with_guessed_format()?;
@@ -207,21 +275,22 @@ impl SplashWindow {
             info!("Image is animated GIF ({}x{}), loading frames...", w, h);
             let gif_cursor = Cursor::new(&img_stream);
             let decoder = GifDecoder::new(gif_cursor)?;
-            let dec_frames = decoder.into_frames();
-            for frame in dec_frames.into_iter() {
+            for frame in decoder.into_frames() {
                 let frame = frame?;
                 let (num, dem) = frame.delay().numer_denom_ms();
                 delays.push((num / dem) as u32);
-                let dynamic = DynamicImage::from(frame.buffer().to_owned());
-                decoded_images.push(dynamic);
+                let mut buf = frame.into_buffer().into_vec();
+                convert_rgba_to_premultiplied_bgra(&mut buf);
+                decoded_images.push(buf);
             }
             info!("Successfully loaded {} frames.", decoded_images.len());
         } else {
             info!("Loading static image (detected {:?})...", fmt);
-            delays.push(16u32); // 60 fps
+            delays.push(16u32);
             let img_cursor = Cursor::new(&img_stream);
-            let img_decoder = ImageReader::new(img_cursor).with_guessed_format()?.decode()?;
-            decoded_images.push(img_decoder);
+            let mut buf = ImageReader::new(img_cursor).with_guessed_format()?.decode()?.into_rgba8().into_vec();
+            convert_rgba_to_premultiplied_bgra(&mut buf);
+            decoded_images.push(buf);
             info!("Successfully loaded.");
         }
 
@@ -263,20 +332,7 @@ impl SplashWindow {
         };
         info!("DPI scale: {}, window size: {}x{} -> {}x{}", dpi_scale, w, h, scaled_w, scaled_h);
 
-        // Pre-scale frames using high-quality Lanczos3 resampling so the bitmaps
-        // match the window size. This avoids blurry GDI stretching at high DPI.
-        let mut frames = Vec::new();
-        for img in &decoded_images {
-            let scaled_img = if scaled_w != w || scaled_h != h {
-                img.resize_exact(scaled_w as u32, scaled_h as u32, FilterType::Lanczos3)
-            } else {
-                img.clone()
-            };
-            let mut vec = scaled_img.to_rgba8().into_vec();
-            convert_rgba_to_bgra(&mut vec);
-            let bitmap = CreateBitmap(scaled_w, scaled_h, 1, 32, Some(vec.as_mut_ptr() as *mut _));
-            frames.push(bitmap);
-        }
+        let frames = scale_frames(&decoded_images, w as u32, h as u32, scaled_w as u32, scaled_h as u32);
 
         let class_name = string_to_wide("VelopackSetupSplashWindow");
         let app_name = string_to_wide(&app_name);
@@ -323,10 +379,11 @@ impl SplashWindow {
 
         let data_ptr = Box::into_raw(Box::new(Self {
             frames,
+            decoded_images,
+            orig_w: w as u32,
+            orig_h: h as u32,
             rx,
             frame_idx: 0,
-            w: scaled_w,
-            h: scaled_h,
             scaled_w,
             scaled_h,
             dpi_scale,
@@ -352,9 +409,7 @@ impl SplashWindow {
 
         let data = Box::from_raw(data_ptr);
         ReleaseDC(Some(hwnd_desktop), data.hdc_screen);
-        for h_bitmap in &data.frames {
-            let _ = DeleteObject((*h_bitmap).into());
-        }
+        drop(data);
 
         let _ = DestroyWindow(hwnd);
         Ok(())
@@ -366,12 +421,13 @@ impl SplashWindow {
                 return HTCAPTION as isize; // make the window draggable
             }
             WM_DPICHANGED => {
-                // Let Windows handle position and size — the suggested rect already
-                // has the correct DPI-scaled dimensions for the new monitor.
                 let suggested = &*(lparam.0 as *const RECT);
                 self.scaled_w = suggested.right - suggested.left;
                 self.scaled_h = suggested.bottom - suggested.top;
                 self.dpi_scale = (wparam.0 & 0xFFFF) as f32 / 96.0;
+
+                self.frames = scale_frames(&self.decoded_images, self.orig_w, self.orig_h, self.scaled_w as u32, self.scaled_h as u32);
+                self.frame_idx = 0;
 
                 let _ = SetWindowPos(
                     hwnd,
@@ -414,10 +470,8 @@ impl SplashWindow {
                     return 0;
                 }
 
-                // get the bitmap for the current frame
-                let h_bitmap = self.frames[self.frame_idx];
+                let h_bitmap = self.frames[self.frame_idx].0;
 
-                // create memory DC with the original frame bitmap
                 let hdc_src = CreateCompatibleDC(Some(self.hdc_screen));
                 let src_old = SelectObject(hdc_src, h_bitmap.into());
 
@@ -426,9 +480,6 @@ impl SplashWindow {
                 let scaled_bitmap = CreateCompatibleBitmap(self.hdc_screen, self.scaled_w, self.scaled_h);
                 let dest_old = SelectObject(hdc_dest, scaled_bitmap.into());
 
-                // stretch the original bitmap to the scaled size using AlphaBlend
-                // to preserve alpha channel during scaling
-                SetStretchBltMode(hdc_dest, STRETCH_HALFTONE);
                 let result = AlphaBlend(
                     hdc_dest,
                     0,
@@ -438,8 +489,8 @@ impl SplashWindow {
                     hdc_src,
                     0,
                     0,
-                    self.w,
-                    self.h,
+                    self.scaled_w,
+                    self.scaled_h,
                     ALPHA_BLEND_FN,
                 );
                 if !result.as_bool() {
@@ -625,6 +676,7 @@ fn test_parse_hex_color_invalid_falls_back_to_green() {
 fn show_splash_gif() {
     let rd = std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/splash-test.gif")).unwrap();
     let tx = show_splash_dialog("osu!".to_string(), Some(rd), SplashOptions::default());
+    std::thread::sleep(std::time::Duration::from_secs(1));
     let _ = tx.send(25);
     std::thread::sleep(std::time::Duration::from_secs(1));
     let _ = tx.send(50);
@@ -670,6 +722,7 @@ fn show_splash_without_progress_bar() {
 #[ignore]
 fn show_splash_progress() {
     let tx = show_progress_dialog("hello!", "this is some content");
+    std::thread::sleep(std::time::Duration::from_secs(1));
     let _ = tx.send(25);
     std::thread::sleep(std::time::Duration::from_secs(1));
     let _ = tx.send(50);


### PR DESCRIPTION
windows custom scaling setting is at `settings > system > display > custom scaling`

**The Problem**
When Windows display scaling is set above 100%, the splash image gets blurry. This is because:
The image bitmap is created at its original pixel dimensions (e.g. 600x400)
The window is sized to DPI-scaled dimensions (e.g. 900x600 at 150%)
During WM_PAINT, GDI's AlphaBlend stretches the small bitmap up to the window size — and GDI's stretching produces poor-quality, blurry results

**The Fix**
Instead of relying on GDI to stretch the image at paint time, the image frames are now pre-scaled using the image crate's Lanczos3 resampling (a high-quality algorithm) before creating the bitmaps. This means:
Bitmaps are created at the window size (already scaled for DPI)
AlphaBlend in WM_PAINT does a 1:1 copy (no stretching) — pixel-perfect
The image crate's Lanczos3 filter produces much sharper results than GDI's STRETCH_HALFTONE

**Changes in splash.rs**
Import FilterType from the image crate (line 2)
Decode phase: Frames are stored as DynamicImage objects instead of immediately converting to HBITMAP (lines 197-226)
New scaling step (lines 266-279): After DPI calculations, each frame is resized to the target window dimensions using FilterType::Lanczos3, then converted to a bitmap at that size
Struct init (lines 328-329): w and h are set to the scaled dimensions since the bitmaps are now pre-scaled