### PR TITLE
Enhances Velopack Flow UpdateManager initialization

### DIFF
--- a/src/lib-cpp/include/Velopack.h
+++ b/src/lib-cpp/include/Velopack.h
@@ -306,6 +306,17 @@ bool vpkc_new_update_manager(const char *psz_url_or_path,
                              vpkc_update_manager_t **p_manager);
 
 /**
+ * Create a new UpdateManager instance using the default VelopackFlowSource.
+ * @param p_options Optional extra configuration for update manager.
+ * @param p_locator Optional explicit path configuration for Velopack. If null, the default locator will be used.
+ * @param p_manager A pointer to where the new vpkc_update_manager_t* instance will be stored.
+ * @returns True if the update manager was created successfully, false otherwise. If false, the error will be available via `vpkc_get_last_error`.
+ */
+bool vpkc_new_update_manager_default(struct vpkc_update_options_t *p_options,
+                                     struct vpkc_locator_config_t *p_locator,
+                                     vpkc_update_manager_t **p_manager);
+
+/**
  * Create a new UpdateManager instance with a custom UpdateSource.
  * @param p_source A pointer to a custom UpdateSource.
  * @param p_options Optional extra configuration for update manager.

--- a/src/lib-cpp/src/lib.rs
+++ b/src/lib-cpp/src/lib.rs
@@ -217,6 +217,28 @@ pub extern "C" fn vpkc_new_update_manager(
     })
 }
 
+/// Create a new UpdateManager instance using the default VelopackFlowSource.
+/// @param p_options Optional extra configuration for update manager.
+/// @param p_locator Optional explicit path configuration for Velopack. If null, the default locator will be used.
+/// @param p_manager A pointer to where the new vpkc_update_manager_t* instance will be stored.
+/// @returns True if the update manager was created successfully, false otherwise. If false, the error will be available via `vpkc_get_last_error`.
+#[no_mangle]
+#[logfn(Trace)]
+#[logfn_inputs(Trace)]
+pub extern "C" fn vpkc_new_update_manager_default(
+    p_options: *mut vpkc_update_options_t,
+    p_locator: *mut vpkc_locator_config_t,
+    p_manager: *mut *mut vpkc_update_manager_t,
+) -> bool {
+    wrap_error(|| {
+        let options = c_to_UpdateOptions(p_options).ok();
+        let locator = c_to_VelopackLocatorConfig(p_locator).ok();
+        let manager = UpdateManager::new_default(options, locator)?;
+        unsafe { *p_manager = UpdateManagerRawPtr::new(manager) };
+        Ok(())
+    })
+}
+
 /// Create a new UpdateManager instance with a custom UpdateSource.
 /// @param p_source A pointer to a custom UpdateSource.
 /// @param p_options Optional extra configuration for update manager.
@@ -711,4 +733,66 @@ pub extern "C" fn vpkc_get_last_error(psz_error: *mut c_char, c_error: size_t) -
 #[no_mangle]
 pub extern "C" fn vpkc_set_logger(cb_log: vpkc_log_callback_t, p_user_data: *mut c_void) {
     set_log_callback(cb_log, p_user_data);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::CStr, fs, path::PathBuf, ptr};
+
+    use super::*;
+    use crate::types::{allocate_VelopackLocatorConfig, free_VelopackLocatorConfig};
+    use tempfile::tempdir;
+    use velopack::locator::VelopackLocatorConfig;
+
+    fn test_manifest_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("test")
+            .join("fixtures")
+            .join("Test.Squirrel-App.nuspec")
+    }
+
+    fn test_locator_config() -> VelopackLocatorConfig {
+        let temp_dir = tempdir().unwrap();
+        let root_dir = temp_dir.into_path();
+        let packages_dir = root_dir.join("packages");
+        let current_binary_dir = root_dir.join("current");
+        let update_exe_path = root_dir.join("Update.exe");
+
+        fs::create_dir_all(&packages_dir).unwrap();
+        fs::create_dir_all(&current_binary_dir).unwrap();
+        fs::write(&update_exe_path, []).unwrap();
+
+        VelopackLocatorConfig {
+            RootAppDir: root_dir,
+            UpdateExePath: update_exe_path,
+            PackagesDir: packages_dir,
+            ManifestPath: test_manifest_path(),
+            CurrentBinaryDir: current_binary_dir,
+            IsPortable: true,
+        }
+    }
+
+    #[test]
+    fn new_update_manager_default_uses_flow_source() {
+        let locator = test_locator_config();
+        let mut manager = ptr::null_mut();
+        let mut app_id = vec![0 as c_char; 128];
+
+        let locator_ptr = unsafe { allocate_VelopackLocatorConfig(&locator) };
+        let ok = vpkc_new_update_manager_default(ptr::null_mut(), locator_ptr, &mut manager);
+
+        assert!(ok);
+        assert!(!manager.is_null());
+
+        let written = vpkc_get_app_id(manager, app_id.as_mut_ptr(), app_id.len());
+        assert!(written > 0);
+
+        let app_id = unsafe { CStr::from_ptr(app_id.as_ptr()) }.to_string_lossy().to_string();
+        assert_eq!(app_id, "Test.Squirrel-App");
+
+        vpkc_free_update_manager(manager);
+        unsafe { free_VelopackLocatorConfig(locator_ptr) };
+    }
 }

--- a/src/lib-csharp/UpdateManager.cs
+++ b/src/lib-csharp/UpdateManager.cs
@@ -73,6 +73,17 @@ namespace Velopack
         protected int MaximumDeltasBeforeFallback { get; }
 
         /// <summary>
+        /// Creates a new UpdateManager instance using the default <see cref="VelopackFlowSource"/>
+        /// </summary>
+        /// <param name="options">Override / configure default update behaviors.</param>
+        /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths. 
+        public UpdateManager(UpdateOptions? options = null, IVelopackLocator? locator = null)
+            : this(new VelopackFlowSource(), options, locator)
+        {
+            
+        }
+
+        /// <summary>
         /// Creates a new UpdateManager instance using the specified URL or file path to the releases feed, and the specified channel name.
         /// </summary>
         /// <param name="urlOrPath">A basic URL or file path to use when checking for updates.</param>
@@ -88,7 +99,7 @@ namespace Velopack
         /// Creates a new UpdateManager instance using the specified URL or file path to the releases feed, and the specified channel name.
         /// </summary>
         /// <param name="source">The source describing where to search for updates. This can be a custom source, if you are integrating with some private resource,
-        /// or it could be one of the predefined sources. (eg. <see cref="SimpleWebSource"/> or <see cref="GithubSource"/>, etc).</param>
+        /// or it could be one of the predefined sources. (eg. <see cref="VelopackFlowSource"/>, <see cref="SimpleWebSource"/>, or <see cref="GithubSource"/>, etc).</param>
         /// <param name="options">Override / configure default update behaviors.</param>
         /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths. 
         /// For example, if you wanted to test that updates are working in a unit test, you could provide an instance of <see cref="TestVelopackLocator"/>. </param>

--- a/src/lib-nodejs/src/index.ts
+++ b/src/lib-nodejs/src/index.ts
@@ -6,7 +6,7 @@ export { UpdateInfo, UpdateOptions, VelopackLocatorConfig, VelopackAsset };
 type UpdateManagerOpaque = {};
 declare module "./load" {
   function js_new_update_manager(
-    urlOrPath: string,
+    urlOrPath: string | null,
     options: string | null,
     locator: string | null,
   ): UpdateManagerOpaque;
@@ -62,6 +62,27 @@ type VelopackHookType =
 type VelopackHook = (version: string) => void;
 
 type LogLevel = "info" | "warn" | "error" | "debug" | "trace";
+
+function isUpdateOptions(value: unknown): value is UpdateOptions {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("ExplicitChannel" in value || "AllowVersionDowngrade" in value || "MaximumDeltasBeforeFallback" in value)
+  );
+}
+
+function isLocatorConfig(value: unknown): value is VelopackLocatorConfig {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("ManifestPath" in value ||
+      "PackagesDir" in value ||
+      "RootAppDir" in value ||
+      "UpdateExePath" in value ||
+      "CurrentBinaryDir" in value ||
+      "IsPortable" in value)
+  );
+}
 
 /** 
  * VelopackApp helps you to handle app activation events correctly.
@@ -199,20 +220,51 @@ export class UpdateManager {
   private readonly opaque: UpdateManagerOpaque;
 
   /**
+   * Create a new UpdateManager instance. Omit the source to use the default Velopack Flow source.
+   */
+  constructor();
+
+  /**
+   * Create a new UpdateManager instance using the default Velopack Flow source.
+   * @param options Optional extra configuration for update manager.
+   * @param locator Override the default locator configuration (usually used for testing / mocks).
+   */
+  constructor(options?: UpdateOptions, locator?: VelopackLocatorConfig);
+
+  /**
    * Create a new UpdateManager instance.
    * @param urlOrPath Location of the update server or path to the local update directory.
    * @param options Optional extra configuration for update manager.
    * @param locator Override the default locator configuration (usually used for testing / mocks).
    */
+  constructor(urlOrPath: string, options?: UpdateOptions, locator?: VelopackLocatorConfig);
+
   constructor(
-    urlOrPath: string,
-    options?: UpdateOptions,
+    urlOrPathOrOptions?: string | UpdateOptions,
+    optionsOrLocator?: UpdateOptions | VelopackLocatorConfig,
     locator?: VelopackLocatorConfig,
   ) {
+    let urlOrPath: string | null = null;
+    let options: UpdateOptions | undefined;
+    let resolvedLocator: VelopackLocatorConfig | undefined;
+
+    if (typeof urlOrPathOrOptions === "string") {
+      urlOrPath = urlOrPathOrOptions;
+      if (isUpdateOptions(optionsOrLocator)) {
+        options = optionsOrLocator;
+        resolvedLocator = locator;
+      } else {
+        resolvedLocator = isLocatorConfig(optionsOrLocator) ? optionsOrLocator : locator;
+      }
+    } else {
+      options = isUpdateOptions(urlOrPathOrOptions) ? urlOrPathOrOptions : undefined;
+      resolvedLocator = isLocatorConfig(optionsOrLocator) ? optionsOrLocator : locator;
+    }
+
     this.opaque = addon.js_new_update_manager(
       urlOrPath,
       options ? JSON.stringify(options) : "",
-      locator ? JSON.stringify(locator) : null,
+      resolvedLocator ? JSON.stringify(resolvedLocator) : null,
     );
   }
 

--- a/src/lib-nodejs/test/UpdateManager.test.ts
+++ b/src/lib-nodejs/test/UpdateManager.test.ts
@@ -1,12 +1,7 @@
-import {copyFileSync, existsSync} from "fs";
-import {
-  UpdateManager,
-  UpdateOptions,
-  VelopackApp,
-  VelopackLocatorConfig,
-} from "../src";
+import { copyFileSync, existsSync } from "fs";
+import { UpdateManager, UpdateOptions, VelopackApp, VelopackLocatorConfig } from "../src";
 import path from "path";
-import {tempd3, fixture, updateExe} from "./helper";
+import { tempd3, fixture, updateExe } from "./helper";
 
 test("UpdateManager detects local update", async () => {
   await tempd3(async (tmpDir, packagesDir, rootDir) => {
@@ -26,18 +21,37 @@ test("UpdateManager detects local update", async () => {
     };
 
     const um = new UpdateManager(tmpDir, options, locator);
-    copyFileSync(
-      fixture("testfeed.json"),
-      path.join(tmpDir, "releases.beta.json"),
-    );
+    copyFileSync(fixture("testfeed.json"), path.join(tmpDir, "releases.beta.json"));
     const update = await um.checkForUpdatesAsync();
 
     expect(update).not.toBeNull();
     expect(update?.TargetFullRelease).not.toBeNull();
     expect(update?.TargetFullRelease?.Version).toBe("1.0.11");
-    expect(update?.TargetFullRelease?.FileName).toBe(
-      "AvaloniaCrossPlat-1.0.11-full.nupkg",
-    );
+    expect(update?.TargetFullRelease?.FileName).toBe("AvaloniaCrossPlat-1.0.11-full.nupkg");
+  });
+});
+
+test("UpdateManager defaults to Velopack Flow when source is omitted", async () => {
+  await tempd3(async (_tmpDir, packagesDir, rootDir) => {
+    const locator: VelopackLocatorConfig = {
+      ManifestPath: "../../test/fixtures/Test.Squirrel-App.nuspec",
+      PackagesDir: packagesDir,
+      RootAppDir: rootDir,
+      UpdateExePath: updateExe(),
+      CurrentBinaryDir: path.join(rootDir, "current"),
+      IsPortable: true,
+    };
+
+    const options: UpdateOptions = {
+      ExplicitChannel: "beta",
+      AllowVersionDowngrade: false,
+      MaximumDeltasBeforeFallback: 10,
+    };
+
+    const um = new UpdateManager(options, locator);
+
+    expect(um.getAppId()).toBe("Test.Squirrel-App");
+    expect(um.getCurrentVersion()).toBe("1.0.0");
   });
 });
 
@@ -59,28 +73,15 @@ test("UpdateManager downloads full update", async () => {
     };
 
     const um = new UpdateManager(feedDir, options, locator);
-    copyFileSync(
-      fixture("testfeed.json"),
-      path.join(feedDir, "releases.beta.json"),
-    );
+    copyFileSync(fixture("testfeed.json"), path.join(feedDir, "releases.beta.json"));
 
-    copyFileSync(
-      fixture("AvaloniaCrossPlat-1.0.11-win-full.nupkg"),
-      path.join(feedDir, "AvaloniaCrossPlat-1.0.11-full.nupkg"),
-    );
+    copyFileSync(fixture("AvaloniaCrossPlat-1.0.11-win-full.nupkg"), path.join(feedDir, "AvaloniaCrossPlat-1.0.11-full.nupkg"));
 
     const update = await um.checkForUpdatesAsync();
 
-    console.log(
-      `about to download update from ${feedDir} to ${packagesDir} ...`,
-    );
-    await um.downloadUpdateAsync(update!, () => {
-    });
+    console.log(`about to download update from ${feedDir} to ${packagesDir} ...`);
+    await um.downloadUpdateAsync(update!, () => {});
 
-    expect(
-      existsSync(
-        path.join(packagesDir, "AvaloniaCrossPlat-1.0.11-full.nupkg"),
-      ),
-    ).toBe(true);
+    expect(existsSync(path.join(packagesDir, "AvaloniaCrossPlat-1.0.11-full.nupkg"))).toBe(true);
   });
 });

--- a/src/lib-nodejs/velopack_nodeffi/src/lib.rs
+++ b/src/lib-nodejs/velopack_nodeffi/src/lib.rs
@@ -16,6 +16,20 @@ struct UpdateManagerWrapper {
 impl Finalize for UpdateManagerWrapper {}
 type BoxedUpdateManager = JsBox<RefCell<UpdateManagerWrapper>>;
 
+fn args_get_source(cx: &mut FunctionContext, i: usize) -> NeonResult<Option<String>> {
+    let arg_source = cx.argument_opt(i);
+    if let Some(js_value) = arg_source {
+        if let Ok(js_string) = js_value.downcast::<JsString, _>(cx) {
+            let arg_source = js_string.value(cx);
+            if !arg_source.is_empty() {
+                return Ok(Some(arg_source));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 fn args_get_locator(cx: &mut FunctionContext, i: usize) -> NeonResult<Option<VelopackLocatorConfig>> {
     let arg_locator = cx.argument_opt(i);
     if let Some(js_value) = arg_locator {
@@ -48,7 +62,7 @@ fn args_array_to_vec_string(cx: &mut FunctionContext, arg: Handle<JsArray>) -> N
 }
 
 fn js_new_update_manager(mut cx: FunctionContext) -> JsResult<BoxedUpdateManager> {
-    let arg_source = cx.argument::<JsString>(0)?.value(&mut cx);
+    let arg_source = args_get_source(&mut cx, 0)?;
     let arg_options = cx.argument::<JsString>(1)?.value(&mut cx);
 
     let mut options: Option<UpdateOptions> = None;
@@ -59,8 +73,14 @@ fn js_new_update_manager(mut cx: FunctionContext) -> JsResult<BoxedUpdateManager
         options = Some(new_opt);
     }
 
-    let source = AutoSource::new(&arg_source);
-    let manager = UpdateManager::new(source, options, locator).or_else(|e| cx.throw_error(e.to_string()))?;
+    let manager = if let Some(arg_source) = arg_source {
+        let source = AutoSource::new(&arg_source);
+        UpdateManager::new(source, options, locator)
+    } else {
+        UpdateManager::new_default(options, locator)
+    }
+    .or_else(|e| cx.throw_error(e.to_string()))?;
+
     let wrapper = UpdateManagerWrapper { manager };
     Ok(cx.boxed(RefCell::new(wrapper)))
 }

--- a/src/lib-python/src/manager.rs
+++ b/src/lib-python/src/manager.rs
@@ -16,10 +16,17 @@ pub struct UpdateManagerWrapper {
 #[pymethods]
 impl UpdateManagerWrapper {
     #[new]
-    #[pyo3(signature = (source, options = None, locator = None))]
-    pub fn new(source: String, options: Option<PyUpdateOptions>, locator: Option<PyVelopackLocatorConfig>) -> Result<Self> {
-        let source = AutoSource::new(&source);
-        let inner = VelopackUpdateManagerRust::new(source, options.map(Into::into), locator.map(Into::into))?;
+    #[pyo3(signature = (source = None, options = None, locator = None))]
+    pub fn new(source: Option<String>, options: Option<PyUpdateOptions>, locator: Option<PyVelopackLocatorConfig>) -> Result<Self> {
+        let options = options.map(Into::into);
+        let locator = locator.map(Into::into);
+        let inner = if let Some(source) = source {
+            let source = AutoSource::new(&source);
+            VelopackUpdateManagerRust::new(source, options, locator)?
+        } else {
+            VelopackUpdateManagerRust::new_default(options, locator)?
+        };
+
         Ok(UpdateManagerWrapper { inner })
     }
 

--- a/src/lib-rust/src/manager.rs
+++ b/src/lib-rust/src/manager.rs
@@ -10,7 +10,7 @@ use crate::{
     constants,
     locator::{self, LocationContext, VelopackLocator, VelopackLocatorConfig},
     misc,
-    sources::UpdateSource,
+    sources::{UpdateSource, VelopackFlowSource},
     Error,
 };
 
@@ -164,6 +164,18 @@ pub enum UpdateCheck {
 }
 
 impl UpdateManager {
+    /// Create a new UpdateManager instance using the default `VelopackFlowSource`.
+    /// This will return an error if the application is not yet installed.
+    /// ## Example:
+    /// ```rust
+    /// use velopack::*;
+    ///
+    /// let um = UpdateManager::new_default(None, None).unwrap();
+    /// ```
+    pub fn new_default(options: Option<UpdateOptions>, locator: Option<VelopackLocatorConfig>) -> Result<UpdateManager, Error> {
+        UpdateManager::new(VelopackFlowSource::new(None), options, locator)
+    }
+
     /// Create a new UpdateManager instance using the specified UpdateSource.
     /// This will return an error if the application is not yet installed.
     /// ## Example:

--- a/src/lib-rust/tests/manager_default.rs
+++ b/src/lib-rust/tests/manager_default.rs
@@ -1,0 +1,39 @@
+use std::{fs, path::PathBuf};
+
+use velopack::{locator::VelopackLocatorConfig, UpdateManager};
+
+fn test_manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("test")
+        .join("fixtures")
+        .join("Test.Squirrel-App.nuspec")
+}
+
+#[test]
+fn new_default_uses_flow_source_without_explicit_source() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_dir = temp_dir.path().join("root");
+    let packages_dir = root_dir.join("packages");
+    let current_binary_dir = root_dir.join("current");
+    let update_exe_path = root_dir.join("Update.exe");
+
+    fs::create_dir_all(&packages_dir).unwrap();
+    fs::create_dir_all(&current_binary_dir).unwrap();
+    fs::write(&update_exe_path, []).unwrap();
+
+    let locator = VelopackLocatorConfig {
+        RootAppDir: root_dir,
+        UpdateExePath: update_exe_path,
+        PackagesDir: packages_dir,
+        ManifestPath: test_manifest_path(),
+        CurrentBinaryDir: current_binary_dir,
+        IsPortable: true,
+    };
+
+    let manager = UpdateManager::new_default(None, Some(locator)).unwrap();
+
+    assert_eq!(manager.get_app_id(), "Test.Squirrel-App");
+    assert_eq!(manager.get_current_version_as_string(), "1.0.0");
+}

--- a/src/vpk/Velopack.Vpk/Program.cs
+++ b/src/vpk/Velopack.Vpk/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -8,13 +8,11 @@ using Serilog.Events;
 using Velopack.Core;
 using Velopack.Core.Abstractions;
 using Velopack.Deployment;
-using Velopack.Flow;
 using Velopack.Flow.Commands;
 using Velopack.Packaging.Commands;
 using Velopack.Packaging.Exceptions;
 using Velopack.Packaging.Unix.Commands;
 using Velopack.Packaging.Windows.Commands;
-using Velopack.Util;
 using Velopack.Vpk.Commands;
 using Velopack.Vpk.Commands.Deployment;
 using Velopack.Vpk.Commands.Flow;
@@ -163,11 +161,11 @@ public class Program
         deltaCommand.AddCommand<DeltaPatchCommand, DeltaPatchCommandRunner, DeltaPatchOptions>(provider);
         rootCommand.Add(deltaCommand);
 
-        HideCommand(rootCommand.AddCommand<LoginCommand, LoginCommandRunner, LoginOptions>(provider));
-        HideCommand(rootCommand.AddCommand<LogoutCommand, LogoutCommandRunner, LogoutOptions>(provider));
-        HideCommand(rootCommand.AddCommand<PublishCommand, PublishCommandRunner, PublishOptions>(provider));
+        rootCommand.AddCommand<LoginCommand, LoginCommandRunner, LoginOptions>(provider);
+        rootCommand.AddCommand<LogoutCommand, LogoutCommandRunner, LogoutOptions>(provider);
+        rootCommand.AddCommand<PublishCommand, PublishCommandRunner, PublishOptions>(provider);
 
-        var flowCommand = new Command("flow", "Commands for interacting with Velopack Flow.") { Hidden = true };
+        var flowCommand = new Command("flow", "Commands for interacting with Velopack Flow.");
         HideCommand(flowCommand.AddCommand<ApiCommand, ApiCommandRunner, ApiOptions>(provider));
         rootCommand.Add(flowCommand); 
 


### PR DESCRIPTION
Introduces simpler `UpdateManager` constructors and methods across multiple language bindings (C++, C#, Node.js, Python, Rust) that automatically configure with `VelopackFlowSource` when no explicit source is provided. This streamlines the setup process for Velopack Flow users.

Additionally, makes Velopack Flow commands visible in the `vpk` CLI, improving discoverability and ease of use.

*   **API Enhancements**:
    *   Adds `vpkc_new_update_manager_default` in C++ to create a manager with the default source.
    *   Introduces a new `UpdateManager` constructor in C# that defaults to `VelopackFlowSource`.
    *   Modifies Node.js and Python `UpdateManager` constructors to accept an optional source, using `VelopackFlowSource` by default if omitted.
    *   Implements `UpdateManager::new_default` in the core Rust library.
*   **CLI Visibility**: Unhides Velopack Flow commands (`flow`, `login`, `logout`, `publish`) in the `vpk` CLI.