### PR TITLE
Set first-run env on portable start when packages dir is missing

### DIFF
--- a/src/bins/src/commands/start_windows_impl.rs
+++ b/src/bins/src/commands/start_windows_impl.rs
@@ -126,6 +126,21 @@ fn start_regular(locator: LocatorResult, exe_name: Option<&OsString>, exe_args: 
     let mut cmd = Process::new(&exe_to_execute);
     cmd.current_dir(&current);
 
+    let root_dir = locator.get_root_dir();
+    let packages_dir = root_dir.join("packages");
+    let portable_marker = root_dir.join(".portable");
+    let should_set_first_run_env = portable_marker.exists() && !packages_dir.exists();
+    if should_set_first_run_env {
+        if let Err(e) = fs::create_dir_all(&packages_dir) {
+            warn!(
+                "Failed to create packages directory for portable first run ({}): {}",
+                packages_dir.display(),
+                e
+            );
+        }
+        cmd.env(constants::HOOK_ENV_FIRSTRUN, "true");
+    }
+
     if let Some(args) = exe_args {
         cmd.args(args);
     } else if let Some(args) = legacy_args {


### PR DESCRIPTION
When running a portable release for the first time it never sets the `VELOPACK_FIRSTRUN` environment variable

The code checks for the `.portable` file in the current directory and that the directory doesn't exists.
The directory `packages` only exists after the first fun.