### PR TITLE
Exclude packages without channel metadata from channel-specific feed requests

### DIFF
--- a/src/lib-csharp/Sources/SimpleFileSource.cs
+++ b/src/lib-csharp/Sources/SimpleFileSource.cs
@@ -49,15 +49,20 @@ namespace Velopack.Sources
                     var zip = new ZipPackage(pkg);
                     var asset = await VelopackAsset.FromZipPackageGenerateChecksumAsync(zip).ConfigureAwait(false);
                     if (asset?.Version != null) {
-                        // If requesting a specific channel, only include packages explicitly in that channel
-                        if (channel != null && (zip?.Channel == null || zip?.Channel != channel)) {
-                            logger.Warn($"Skipping local package '{pkg}' because it is not in the '{channel}' channel.");
-                            continue;
+                        if (channel != null) {
+                            // If requesting a specific channel, only include packages explicitly in that channel.
+                            // Packages without channel metadata (e.g. legacy Squirrel releases) are excluded.
+                            if (zip?.Channel == channel) {
+                                logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
+                                list.Add(asset);
+                            } else {
+                                logger.Warn($"Skipping local package '{pkg}' because it is not in the '{channel}' channel.");
+                            }
+                        } else {
+                            // If no specific channel requested, include all packages regardless of channel.
+                            logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
+                            list.Add(asset);
                         }
-
-                        // If no specific channel requested (channel == null), include all packages
-                        logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
-                        list.Add(asset);
                     }
                 } catch (Exception ex) {
                     logger.Warn(ex, $"Error while reading local package '{pkg}'.");

--- a/src/lib-csharp/Sources/SimpleFileSource.cs
+++ b/src/lib-csharp/Sources/SimpleFileSource.cs
@@ -49,12 +49,15 @@ namespace Velopack.Sources
                     var zip = new ZipPackage(pkg);
                     var asset = await VelopackAsset.FromZipPackageGenerateChecksumAsync(zip).ConfigureAwait(false);
                     if (asset?.Version != null) {
-                        if (channel == null || zip?.Channel == null || zip?.Channel == channel) {
-                            logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
-                            list.Add(asset);
-                        } else {
+                        // If requesting a specific channel, only include packages explicitly in that channel
+                        if (channel != null && (zip?.Channel == null || zip?.Channel != channel)) {
                             logger.Warn($"Skipping local package '{pkg}' because it is not in the '{channel}' channel.");
+                            continue;
                         }
+
+                        // If no specific channel requested (channel == null), include all packages
+                        logger.Debug($"Read package '{pkg}' with version '{asset.Version}' in channel '{zip?.Channel}'.");
+                        list.Add(asset);
                     }
                 } catch (Exception ex) {
                     logger.Warn(ex, $"Error while reading local package '{pkg}'.");


### PR DESCRIPTION
Rebased version of #747 with merge conflicts resolved against current `develop`.

Closes #747
Closes #746 