### PR TITLE
Add --noDefaultExclude to opt out of built-in file exclusions

### DIFF
--- a/src/vpk/Velopack.Build/PackTask.cs
+++ b/src/vpk/Velopack.Build/PackTask.cs
@@ -50,6 +50,8 @@ public class PackTask : MSBuildAsyncTask
 
     public string? Exclude { get; set; }
 
+    public bool NoDefaultExclude { get; set; }
+
     public bool NoPortable { get; private set; }
 
     public bool NoInst { get; private set; }

--- a/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/LinuxPackOptions.cs
@@ -31,6 +31,8 @@ public class LinuxPackOptions : IPackOptions
 
     public string Exclude { get; set; }
 
+    public bool NoDefaultExclude { get; set; }
+
     public bool NoPortable { get; set; }
 
     public bool NoInst { get; set; }

--- a/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Unix/Commands/OsxPackOptions.cs
@@ -38,4 +38,6 @@ public class OsxPackOptions : OsxBundleOptions, IPackOptions
     public string Channel { get; set; }
 
     public string Exclude { get; set; }
+
+    public bool NoDefaultExclude { get; set; }
 }

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
@@ -18,6 +18,8 @@ public class WindowsPackOptions : WindowsReleasifyOptions, INugetPackCommand, IP
 
     public string Exclude { get; set; }
 
+    public bool NoDefaultExclude { get; set; }
+
     public bool NoPortable { get; set; }
 
     public bool NoInst { get; set; }

--- a/src/vpk/Velopack.Packaging/Abstractions/IPackOptions.cs
+++ b/src/vpk/Velopack.Packaging/Abstractions/IPackOptions.cs
@@ -9,6 +9,7 @@ public interface IPackOptions : INugetPackCommand, IPlatformOptions
     string EntryExecutableName { get; set; }
     string Icon { get; set; }
     string Exclude { get; set; }
+    bool NoDefaultExclude { get; set; }
     bool NoPortable { get; set; }
     bool NoInst { get; set; }
 }

--- a/src/vpk/Velopack.Packaging/PackageBuilder.cs
+++ b/src/vpk/Velopack.Packaging/PackageBuilder.cs
@@ -312,6 +312,8 @@ public abstract class PackageBuilder<T> : ICommand<T>
             manualExclude = new Regex(Options.Exclude, RegexOptions.Compiled);
         }
 
+        var defaultExclude = Options.NoDefaultExclude ? null : REGEX_EXCLUDES;
+
         if (!source.Exists) {
             throw new ArgumentException("Source directory does not exist: " + source.FullName);
         }
@@ -327,7 +329,7 @@ public abstract class PackageBuilder<T> : ICommand<T>
                     var path = Path.Combine(target.FullName, fileInfo.Name);
                     currentFile++;
                     progress((int) ((double) currentFile / numFiles * 100));
-                    if (excludeAnnoyances && (REGEX_EXCLUDES.IsMatch(path) || manualExclude?.IsMatch(path) == true)) {
+                    if (excludeAnnoyances && (defaultExclude?.IsMatch(path) == true || manualExclude?.IsMatch(path) == true)) {
                         Log.Debug("Skipping because matched exclude pattern: " + path);
                         continue;
                     }
@@ -351,7 +353,7 @@ public abstract class PackageBuilder<T> : ICommand<T>
 
             if (excludeAnnoyances) {
                 foreach (var f in target.EnumerateFiles("*", SearchOption.AllDirectories)) {
-                    if (excludeAnnoyances && (REGEX_EXCLUDES.IsMatch(f.FullName) || manualExclude?.IsMatch(f.FullName) == true)) {
+                    if (defaultExclude?.IsMatch(f.FullName) == true || manualExclude?.IsMatch(f.FullName) == true) {
                         Log.Debug("Deleting because matched exclude pattern: " + f.FullName);
                         f.Delete();
                     }

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/PackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/PackCommand.cs
@@ -46,6 +46,10 @@ public abstract class PackCommand : PlatformCommand
 
     protected Option<string> ExcludeOption { get; private set; }
 
+    public bool NoDefaultExclude { get; private set; }
+
+    protected Option<bool> NoDefaultExcludeOption { get; private set; }
+
     public bool NoPortable { get; private set; }
 
     protected Option<bool> NoPortableOption { get; private set; }
@@ -102,9 +106,13 @@ public abstract class PackCommand : PlatformCommand
             .SetArgumentHelpName("NAME");
 
         ExcludeOption = AddOption<string>((v) => Exclude = v, "--exclude")
-            .SetDescription("A regex which excludes matched files from the package.")
+            .SetDescription("A regex which excludes matched files from the package (in addition to built-in defaults).")
             .SetArgumentHelpName("REGEX")
             .SetDefault(@".*\.pdb");
+
+        NoDefaultExcludeOption = AddOption<bool>((v) => NoDefaultExclude = v, "--noDefaultExclude")
+            .SetDescription("Do not exclude built-in default file patterns (eg. .nupkg, createdump, .vshost.).")
+            .SetHidden(true);
 
         NoPortableOption = AddOption<bool>((v) => NoPortable = v, "--noPortable")
             .SetDescription("Skip generating a portable bundle.")


### PR DESCRIPTION
Adds a hidden `--noDefaultExclude` flag (plus matching `IPackOptions` / MSBuild `PackTask` property) that disables the built-in `REGEX_EXCLUDES` list (`.nupkg`, `createdump*`, `*.vshost.*`).

These hardcoded excludes act as a footgun guard, but there was no way to opt out of them. Some legitimate use-cases need to ship those files (eg. bundling `createdump` for crash reporting, or a nested `.nupkg` payload). `--exclude` remains additive to the defaults — `--noDefaultExclude` is a separate explicit opt-out.

Closes #583
Closes #585