### PR TITLE
Fix shasum parsing for filenames with spaces

### DIFF
--- a/src/vpk/Velopack.Packaging/Compression/DeltaPackage.cs
+++ b/src/vpk/Velopack.Packaging/Compression/DeltaPackage.cs
@@ -173,8 +173,8 @@ namespace Velopack.Packaging.Compression
         void verifyPatchedFile(string relativeFilePath, string inputFile, string tempTargetFile)
         {
             var shaFile = DIFF_SUFFIX.Replace(inputFile, ".shasum");
+            var expectedReleaseEntry = ParseShasumEntry(File.ReadAllText(shaFile, Encoding.UTF8));
 #pragma warning disable CS0618 // Type or member is obsolete
-            var expectedReleaseEntry = ReleaseEntry.ParseReleaseEntry(File.ReadAllText(shaFile, Encoding.UTF8));
             var actualReleaseEntry = ReleaseEntry.GenerateFromFile(tempTargetFile);
 #pragma warning restore CS0618 // Type or member is obsolete
 
@@ -187,6 +187,33 @@ namespace Velopack.Packaging.Compression
                 Log.Error($"Patched file {relativeFilePath} has incorrect SHA1, expected {expectedReleaseEntry.SHA1}, got {actualReleaseEntry.SHA1}");
                 throw new ChecksumFailedException(relativeFilePath);
             }
+        }
+
+        static (string SHA1, long Filesize) ParseShasumEntry(string entry)
+        {
+            entry = CoreUtil.RemoveByteOrderMarkerIfPresent(entry).Trim();
+
+            var firstSeparator = entry.IndexOfAny([' ', '\t']);
+            var lastSeparator = entry.LastIndexOfAny([' ', '\t']);
+
+            if (firstSeparator <= 0 ||
+                lastSeparator <= firstSeparator ||
+                lastSeparator == entry.Length - 1) {
+                throw new InvalidDataException("Invalid shasum entry: " + entry);
+            }
+
+            var sha1 = entry[..firstSeparator];
+            var filename = entry[(firstSeparator + 1)..lastSeparator].Trim();
+            var filesizeText = entry[(lastSeparator + 1)..];
+
+            if (filename.Length == 0 ||
+                sha1.Length != 40 ||
+                sha1.Any(x => !Uri.IsHexDigit(x)) ||
+                !long.TryParse(filesizeText, out var filesize)) {
+                throw new InvalidDataException("Invalid shasum entry: " + entry);
+            }
+
+            return (sha1, filesize);
         }
     }
 }

--- a/test/Velopack.Packaging.Tests/DeltaPackageTests.cs
+++ b/test/Velopack.Packaging.Tests/DeltaPackageTests.cs
@@ -1,5 +1,6 @@
 ﻿using Velopack.Core;
 using Velopack.Packaging.Commands;
+using Velopack.Packaging.Compression;
 using Velopack.Util;
 
 namespace Velopack.Packaging.Tests;
@@ -94,6 +95,66 @@ public class ApplyDeltaPackageTests(ITestOutputHelper output)
         // var result = new ZipPackage(outFile);
         // result.Id.ShouldEqual("Clowd");
         // result.Version.ShouldEqual(SemanticVersion.Parse("3.4.292"));
+    }
+
+    [Fact]
+    public async Task AppliesDeltaForChangedFileWithSpacesInName()
+    {
+        using var _1 = TempUtil.GetTempDirectory(out var temp);
+        using var logger = output.BuildLoggerFor<ApplyDeltaPackageTests>();
+
+        var basePackage = Path.Combine(temp, "SpaceFileTest-1.0.0-full.nupkg");
+        var newPackage = Path.Combine(temp, "SpaceFileTest-2.0.0-full.nupkg");
+        var deltaPackage = Path.Combine(temp, "SpaceFileTest-2.0.0-delta.nupkg");
+        var outputPackage = Path.Combine(temp, "SpaceFileTest-2.0.0-patched.nupkg");
+
+        await CreateTestPackage(logger, basePackage, "SpaceFileTest", "1.0.0", "version one");
+        await CreateTestPackage(logger, newPackage, "SpaceFileTest", "2.0.0", "version two");
+
+        var deltaBuilder = new DeltaPackageBuilder(logger);
+        deltaBuilder.CreateDeltaPackage(
+            new ReleasePackage(basePackage),
+            new ReleasePackage(newPackage),
+            deltaPackage,
+            DeltaMode.BestSpeed,
+            _ => { });
+
+        var runner = new DeltaPatchCommandRunner(logger, new LoggerConsole(logger));
+        await runner.Run(
+            new DeltaPatchOptions {
+                BasePackage = basePackage,
+                OutputFile = outputPackage,
+                PatchFiles = [new FileInfo(deltaPackage)],
+            });
+
+        Assert.True(DeltaPackageBuilder.AreFilesEqualFast(outputPackage, newPackage));
+    }
+
+    private static async Task CreateTestPackage(ILogger logger, string packagePath, string id, string version, string fileContent)
+    {
+        using var _1 = TempUtil.GetTempDirectory(out var packageRoot);
+        var libDir = Path.Combine(packageRoot, "lib", "app");
+        Directory.CreateDirectory(libDir);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(libDir, "File With Spaces.txt"),
+            fileContent);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(packageRoot, $"{id}.nuspec"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>{id}</id>
+                <version>{version}</version>
+                <authors>Velopack</authors>
+                <description>Delta regression test package.</description>
+              </metadata>
+            </package>
+            """);
+
+        await EasyZip.CreateZipFromDirectoryAsync(logger.ToVelopackLogger(), packagePath, packageRoot);
     }
 
     // [Fact(Skip = "Rewrite this test, the original uses too many heavyweight fixtures")]


### PR DESCRIPTION
## Summary

Fixes delta patch verification for changed files with spaces in their filenames.

The `.shasum` entry already contains the SHA1, filename, and filesize. This change parses it by reading the SHA1 from the first separator, the filesize from the last separator, and treating everything between them as the filename.

This keeps filenames with spaces intact while parsing the checksum and filesize.

## Validation

- `dotnet build`
- `dotnet test .\test\Velopack.Packaging.Tests\Velopack.Packaging.Tests.csproj -- --filter-class Velopack.Packaging.Tests.ApplyDeltaPackageTests`

`ApplyDeltaPackageTests`: 2 passed, 0 failed.