### PR TITLE
Add Nullable Annotation To `SemanticVersion.TryParse()`

### DIFF
--- a/src/lib-csharp/NuGet/PackageManifest.cs
+++ b/src/lib-csharp/NuGet/PackageManifest.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -43,13 +44,13 @@ namespace Velopack.NuGet
             return nu;
         }
 
-        public static bool TryParseFromFile(string filePath, out PackageManifest manifest)
+        public static bool TryParseFromFile(string filePath, [MaybeNullWhen(false)] out PackageManifest manifest)
         {
             try {
                 manifest = ParseFromFile(filePath);
                 return true;
             } catch {
-                manifest = null!;
+                manifest = null;
                 return false;
             }
         }

--- a/src/lib-csharp/SemanticVersion.cs
+++ b/src/lib-csharp/SemanticVersion.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Velopack
@@ -94,18 +95,14 @@ namespace Velopack
         public static SemanticVersion Parse(string value)
         {
             if (TryParse(value, out var result))
-                return result!;
+                return result;
             throw new ArgumentException($"'{value}' is not a valid semantic version.", nameof(value));
         }
 
         /// <summary>
         /// Try to parse a version string. Returns false if the string is not a valid semantic version.
         /// </summary>
-        #if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
-        public static bool TryParse(string? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out SemanticVersion? version)
-        #else
-        public static bool TryParse(string? value, out SemanticVersion? version)
-        #endif
+        public static bool TryParse(string? value, [NotNullWhen(true)] out SemanticVersion? version)
         {
             version = null;
             if (string.IsNullOrWhiteSpace(value))

--- a/src/lib-csharp/SemanticVersion.cs
+++ b/src/lib-csharp/SemanticVersion.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -101,7 +101,11 @@ namespace Velopack
         /// <summary>
         /// Try to parse a version string. Returns false if the string is not a valid semantic version.
         /// </summary>
+        #if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
+        public static bool TryParse(string? value, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out SemanticVersion version)
+        #else
         public static bool TryParse(string? value, out SemanticVersion? version)
+        #endif
         {
             version = null;
             if (string.IsNullOrWhiteSpace(value))

--- a/src/lib-csharp/SemanticVersion.cs
+++ b/src/lib-csharp/SemanticVersion.cs
@@ -102,7 +102,7 @@ namespace Velopack
         /// Try to parse a version string. Returns false if the string is not a valid semantic version.
         /// </summary>
         #if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)
-        public static bool TryParse(string? value, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out SemanticVersion version)
+        public static bool TryParse(string? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out SemanticVersion? version)
         #else
         public static bool TryParse(string? value, out SemanticVersion? version)
         #endif

--- a/src/lib-csharp/Util/CoreUtil.cs
+++ b/src/lib-csharp/Util/CoreUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -119,7 +120,7 @@ namespace Velopack.Util
             task.ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        public static bool TryParseEnumU16<TEnum>(ushort enumValue, out TEnum? retVal)
+        public static bool TryParseEnumU16<TEnum>(ushort enumValue, [NotNullWhen(true)] out TEnum? retVal)
         {
             retVal = default;
             bool success = Enum.IsDefined(typeof(TEnum), enumValue);

--- a/src/lib-csharp/Util/SymbolicLink.cs
+++ b/src/lib-csharp/Util/SymbolicLink.cs
@@ -131,7 +131,7 @@ namespace Velopack.Util
             string target;
 
 #if NET6_0_OR_GREATER
-            target = fsi!.LinkTarget!;
+            target = fsi.LinkTarget!;
 #else
             if (VelopackRuntimeInfo.IsWindows) {
                 target = WindowsReadLink(linkPath);
@@ -148,7 +148,7 @@ namespace Velopack.Util
             return target;
         }
 
-        private static bool TryGetLinkFsi(string path, out FileSystemInfo? fsi)
+        private static bool TryGetLinkFsi(string path, [NotNullWhen(true)] out FileSystemInfo? fsi)
         {
             fsi = null;
             if (Directory.Exists(path)) {
@@ -164,9 +164,7 @@ namespace Velopack.Util
             return (fsi.Attributes & FileAttributes.ReparsePoint) != 0;
         }
 
-#if NET6_0_OR_GREATER
         [DoesNotReturn]
-#endif
         private static void ThrowPathNotASymlinkException(string path)
         {
             throw new IOException($"The path '{path}' is not a symbolic link or junction point.");

--- a/src/lib-csharp/VelopackRuntimeInfo.cs
+++ b/src/lib-csharp/VelopackRuntimeInfo.cs
@@ -39,6 +39,32 @@ namespace System.Runtime.CompilerServices
 }
 #endif
 
+#if !NETCOREAPP3_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+}
+#endif
+
 namespace Velopack
 {
     // constants from winnt.h


### PR DESCRIPTION
This PR adds `MaybeNullWhenAttribute` to the `TryParse()` method of `SemanticVersion` for supported target frameworks. This will enable proper [null-state static analysis](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis) and mirror the previously used `SematicVersion` from `NuGet.Versioning` (their implementation didn't enable nullability in the first place to avoid this issue).