### PR TITLE
Ignore pyo3 RUSTSEC-2026-0176/0177 advisories in cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,10 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "no drop-in replacement yet" },
     # time segfault only affects Unix with specific env manipulation; not exploitable in our context
     { id = "RUSTSEC-2020-0071", reason = "only affects Unix setenv race; not exploitable in our usage" },
+    # pyo3 out-of-bounds read in Iterator::nth/nth_back for PyList/PyTuple iterators; fixed in 0.29
+    { id = "RUSTSEC-2026-0176", reason = "lib-python does not use nth/nth_back on PyList/PyTuple iterators" },
+    # pyo3 missing Sync bound on PyCFunction::new_closure closures; fixed in 0.29
+    { id = "RUSTSEC-2026-0177", reason = "lib-python does not use PyCFunction::new_closure" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

CI (`build-tests / supply-chain`) is failing on `cargo deny check` due to two new RUSTSEC advisories against pyo3 0.28.3 (both fixed in 0.29.0, pulled in via `velopack_python`):

- **RUSTSEC-2026-0176** — out-of-bounds read in `Iterator::nth` / `nth_back` for `PyList`/`PyTuple` iterators
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure` closures

Neither vulnerable API is used anywhere in `src/lib-python` (verified by grep for `nth`, `nth_back`, and `new_closure`), so this adds both IDs to the `[advisories] ignore` list in `deny.toml` with reasons, rather than taking the pyo3 0.28 → 0.29 semver-major bump.