### PR TITLE
Ship 64-bit Windows bootstrapper binaries from vpk pack

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_wait_seconds: 900
-          artifacts: rust-macos,rust-windows,rust-ubuntu-bins-x64,rust-ubuntu-bins-arm64
+          artifacts: rust-macos,rust-windows,rust-windows-arm64,rust-ubuntu-bins-x64,rust-ubuntu-bins-arm64
           verbose: true
       ## BUILD AND UPLOAD CROSS COMPILE ARTIFACTS
       - name: Download Rust Artifacts

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -41,6 +41,12 @@
       <None Include="$(MSBuildThisFileDirectory)..\target\release\update.exe" Pack="true" PackagePath="vendor" />
       <None Include="$(MSBuildThisFileDirectory)..\target\release\setup.exe" Pack="true" PackagePath="vendor" />
       <None Include="$(MSBuildThisFileDirectory)..\target\release\stub.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\update_x64.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\setup_x64.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\stub_x64.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\update_arm64.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\setup_arm64.exe" Pack="true" PackagePath="vendor" />
+      <None Include="$(MSBuildThisFileDirectory)..\target\release\stub_arm64.exe" Pack="true" PackagePath="vendor" />
       <None Include="$(MSBuildThisFileDirectory)..\target\release\UpdateMac" Pack="true" PackagePath="vendor" />
       <None Include="$(MSBuildThisFileDirectory)..\target\release\UpdateNix_x64" Pack="true" PackagePath="vendor" />
       <None Include="$(MSBuildThisFileDirectory)..\target\release\UpdateNix_arm64" Pack="true" PackagePath="vendor" />

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -206,7 +206,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         List<string> filesToSign = new();
 
         var bundledZip = new ZipPackage(releasePkg);
-        IoUtil.Retry(() => File.Copy(HelperFile.GetSetupPath(Options.TargetRuntime), targetSetupExe, true));
+        IoUtil.Retry(() => File.Copy(HelperFile.GetSetupPath(Options.TargetRuntime, Log), targetSetupExe, true));
         setupExeProgress(10);
 
         var editor = new ResourceEdit(targetSetupExe, Log);
@@ -297,7 +297,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         }
 
         try {
-            IoUtil.Retry(() => File.Copy(HelperFile.GetStubExecutablePath(Options.TargetRuntime), targetStubPath, true));
+            IoUtil.Retry(() => File.Copy(HelperFile.GetStubExecutablePath(Options.TargetRuntime, Log), targetStubPath, true));
             var edit = new ResourceEdit(targetStubPath, Log);
             edit.CopyResourcesFrom(exeToCopy);
             edit.Commit();

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -206,7 +206,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         List<string> filesToSign = new();
 
         var bundledZip = new ZipPackage(releasePkg);
-        IoUtil.Retry(() => File.Copy(HelperFile.SetupPath, targetSetupExe, true));
+        IoUtil.Retry(() => File.Copy(HelperFile.GetSetupPath(Options.TargetRuntime), targetSetupExe, true));
         setupExeProgress(10);
 
         var editor = new ResourceEdit(targetSetupExe, Log);
@@ -297,7 +297,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         }
 
         try {
-            IoUtil.Retry(() => File.Copy(HelperFile.StubExecutablePath, targetStubPath, true));
+            IoUtil.Retry(() => File.Copy(HelperFile.GetStubExecutablePath(Options.TargetRuntime), targetStubPath, true));
             var edit = new ResourceEdit(targetStubPath, Log);
             edit.CopyResourcesFrom(exeToCopy);
             edit.Commit();

--- a/src/vpk/Velopack.Packaging/HelperFile.cs
+++ b/src/vpk/Velopack.Packaging/HelperFile.cs
@@ -9,14 +9,20 @@ public static class HelperFile
     private static string GetUpdateExeName(RID target, ILogger log)
     {
         switch (target.BaseRID) {
+#if DEBUG
         case RuntimeOs.Windows:
             return FindHelperFile("update.exe");
-#if DEBUG
         case RuntimeOs.Linux:
             return FindHelperFile("update");
         case RuntimeOs.OSX:
             return FindHelperFile("update");
 #else
+        case RuntimeOs.Windows:
+            return target.Architecture switch {
+                RuntimeCpu.arm64 => FindHelperFile("update_arm64.exe"),
+                RuntimeCpu.x64 => FindHelperFile("update_x64.exe"),
+                _ => FindHelperFile("update.exe"),
+            };
         case RuntimeOs.Linux:
             if (!target.HasArchitecture) {
                 log.LogWarning("No architecture specified with --runtime, defaulting to x64. If this was not intended please specify via the --runtime parameter");
@@ -79,9 +85,31 @@ public static class HelperFile
 
     public static string AppImageRuntimeX86 => FindHelperFile("appimagekit-runtime-i686");
 
-    public static string SetupPath => FindHelperFile("setup.exe");
+    public static string GetSetupPath(RID target)
+    {
+#if DEBUG
+        return FindHelperFile("setup.exe");
+#else
+        return target.Architecture switch {
+            RuntimeCpu.arm64 => FindHelperFile("setup_arm64.exe"),
+            RuntimeCpu.x64 => FindHelperFile("setup_x64.exe"),
+            _ => FindHelperFile("setup.exe"),
+        };
+#endif
+    }
 
-    public static string StubExecutablePath => FindHelperFile("stub.exe");
+    public static string GetStubExecutablePath(RID target)
+    {
+#if DEBUG
+        return FindHelperFile("stub.exe");
+#else
+        return target.Architecture switch {
+            RuntimeCpu.arm64 => FindHelperFile("stub_arm64.exe"),
+            RuntimeCpu.x64 => FindHelperFile("stub_x64.exe"),
+            _ => FindHelperFile("stub.exe"),
+        };
+#endif
+    }
 
     [SupportedOSPlatform("windows")]
     public static string WixPath => FindHelperFile($"wix\\wixc7.exe");

--- a/src/vpk/Velopack.Packaging/HelperFile.cs
+++ b/src/vpk/Velopack.Packaging/HelperFile.cs
@@ -6,7 +6,7 @@ namespace Velopack.Packaging;
 
 public static class HelperFile
 {
-    private static string GetUpdateExeName(RID target, ILogger log)
+    public static string GetUpdatePath(RID target, ILogger log)
     {
         switch (target.BaseRID) {
 #if DEBUG
@@ -18,10 +18,16 @@ public static class HelperFile
             return FindHelperFile("update");
 #else
         case RuntimeOs.Windows:
+            if (!target.HasArchitecture) {
+                log.LogWarning("No architecture specified with --runtime, defaulting to x86. If this was not intended please specify via the --runtime parameter");
+                return FindHelperFile("update.exe");
+            }
+
             return target.Architecture switch {
                 RuntimeCpu.arm64 => FindHelperFile("update_arm64.exe"),
                 RuntimeCpu.x64 => FindHelperFile("update_x64.exe"),
-                _ => FindHelperFile("update.exe"),
+                RuntimeCpu.x86 => FindHelperFile("update.exe"),
+                _ => throw new PlatformNotSupportedException($"Update binary is not available for this platform ({target})."),
             };
         case RuntimeOs.Linux:
             if (!target.HasArchitecture) {
@@ -55,10 +61,7 @@ public static class HelperFile
             _ => throw new PlatformNotSupportedException($"Wix binary is not available for this platform ({target}).")
         };
 #endif
-        // return @"C:\Source\velopack\target\debug\velopack_wix.dll";
     }
-
-    public static string GetUpdatePath(RID target, ILogger log) => FindHelperFile(GetUpdateExeName(target, log));
 
     public static string GetZstdPath()
     {
@@ -85,28 +88,40 @@ public static class HelperFile
 
     public static string AppImageRuntimeX86 => FindHelperFile("appimagekit-runtime-i686");
 
-    public static string GetSetupPath(RID target)
+    public static string GetSetupPath(RID target, ILogger log)
     {
 #if DEBUG
         return FindHelperFile("setup.exe");
 #else
+        if (!target.HasArchitecture) {
+            log.LogWarning("No architecture specified with --runtime, defaulting to x86. If this was not intended please specify via the --runtime parameter");
+            return FindHelperFile("setup.exe");
+        }
+
         return target.Architecture switch {
             RuntimeCpu.arm64 => FindHelperFile("setup_arm64.exe"),
             RuntimeCpu.x64 => FindHelperFile("setup_x64.exe"),
-            _ => FindHelperFile("setup.exe"),
+            RuntimeCpu.x86 => FindHelperFile("setup.exe"),
+            _ => throw new PlatformNotSupportedException($"Setup binary is not available for this platform ({target})."),
         };
 #endif
     }
 
-    public static string GetStubExecutablePath(RID target)
+    public static string GetStubExecutablePath(RID target, ILogger log)
     {
 #if DEBUG
         return FindHelperFile("stub.exe");
 #else
+        if (!target.HasArchitecture) {
+            log.LogWarning("No architecture specified with --runtime, defaulting to x86. If this was not intended please specify via the --runtime parameter");
+            return FindHelperFile("stub.exe");
+        }
+
         return target.Architecture switch {
             RuntimeCpu.arm64 => FindHelperFile("stub_arm64.exe"),
             RuntimeCpu.x64 => FindHelperFile("stub_x64.exe"),
-            _ => FindHelperFile("stub.exe"),
+            RuntimeCpu.x86 => FindHelperFile("stub.exe"),
+            _ => throw new PlatformNotSupportedException($"Stub binary is not available for this platform ({target})."),
         };
 #endif
     }

--- a/test/Velopack.Pack.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Pack.Tests/WindowsPackTests.cs
@@ -834,11 +834,8 @@ public class WindowsPackTests
     public void PackIncludesCorrectArchitectureBinaries(string architecture, AsmResolver.PE.File.MachineType expectedMachineType)
     {
         Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
-#if DEBUG
-        // Architecture-specific binary selection only happens in Release builds; DEBUG always
-        // uses the single host-built update.exe/setup.exe/stub.exe regardless of target arch.
-        Assert.Skip("Architecture-specific binary selection only applies to Release builds.");
-#else
+        Assert.SkipWhen(IsDebugBuild(), "Architecture-specific binary selection only applies to Release builds.");
+
         using var logger = _output.BuildLoggerFor<WindowsPackTests>();
         using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
         using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
@@ -862,7 +859,6 @@ public class WindowsPackTests
         var runner = WindowsTestHelper.GetPackRunner(logger);
         runner.Run(options).GetAwaiterResult();
 
-        // The update binary is shipped as Squirrel.exe inside the package — it must match the target arch.
         var nupkgPath = Path.Combine(tmpReleaseDir, $"{id}-{version}-full.nupkg");
         Assert.True(File.Exists(nupkgPath));
         EasyZip.ExtractZipToDirectory(logger.ToVelopackLogger(), nupkgPath, unzipDir);
@@ -871,21 +867,24 @@ public class WindowsPackTests
         Assert.True(File.Exists(squirrelExePath), "Expected Squirrel.exe (Update.exe) in the package");
         AssertMachineType(squirrelExePath, expectedMachineType);
 
-        // The Setup.exe bootstrapper must also match the target arch. A 32-bit Setup.exe memory-maps
-        // its embedded package on a process where isize caps at ~2 GiB, so installing a package larger
-        // than 2 GiB fails with "memory map length overflows isize". Shipping a 64-bit Setup.exe lifts that.
         var setupPath = Path.Combine(tmpReleaseDir, $"{id}-win-Setup.exe");
         Assert.True(File.Exists(setupPath), "Expected Setup.exe in the release dir");
         AssertMachineType(setupPath, expectedMachineType);
+    }
+
+    private static bool IsDebugBuild()
+    {
+#if DEBUG
+        return true;
+#else
+        return false;
 #endif
     }
 
-#if !DEBUG
     private void AssertMachineType(string pePath, AsmResolver.PE.File.MachineType expected)
     {
         var actual = AsmResolver.PE.PEImage.FromFile(pePath).MachineType;
         _output.WriteLine($"{Path.GetFileName(pePath)} machine type: {actual}, expected: {expected}");
         Assert.Equal(expected, actual);
     }
-#endif
 }

--- a/test/Velopack.Pack.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Pack.Tests/WindowsPackTests.cs
@@ -826,4 +826,66 @@ public class WindowsPackTests
             File.WriteAllText(testStringFile, oldText);
         }
     }
+
+    [Theory]
+    [InlineData("x86", AsmResolver.PE.File.MachineType.I386)]
+    [InlineData("x64", AsmResolver.PE.File.MachineType.Amd64)]
+    [InlineData("arm64", AsmResolver.PE.File.MachineType.Arm64)]
+    public void PackIncludesCorrectArchitectureBinaries(string architecture, AsmResolver.PE.File.MachineType expectedMachineType)
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+#if DEBUG
+        // Architecture-specific binary selection only happens in Release builds; DEBUG always
+        // uses the single host-built update.exe/setup.exe/stub.exe regardless of target arch.
+        Assert.Skip("Architecture-specific binary selection only applies to Release builds.");
+#else
+        using var logger = _output.BuildLoggerFor<WindowsPackTests>();
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+        using var _3 = TempUtil.GetTempDirectory(out var unzipDir);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+        var version = "1.0.0";
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = version,
+            TargetRuntime = RID.Parse($"win-{architecture}"),
+            PackDirectory = tmpOutput,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        runner.Run(options).GetAwaiterResult();
+
+        // The update binary is shipped as Squirrel.exe inside the package — it must match the target arch.
+        var nupkgPath = Path.Combine(tmpReleaseDir, $"{id}-{version}-full.nupkg");
+        Assert.True(File.Exists(nupkgPath));
+        EasyZip.ExtractZipToDirectory(logger.ToVelopackLogger(), nupkgPath, unzipDir);
+
+        var squirrelExePath = Path.Combine(unzipDir, "lib", "app", "Squirrel.exe");
+        Assert.True(File.Exists(squirrelExePath), "Expected Squirrel.exe (Update.exe) in the package");
+        AssertMachineType(squirrelExePath, expectedMachineType);
+
+        // The Setup.exe bootstrapper must also match the target arch. A 32-bit Setup.exe memory-maps
+        // its embedded package on a process where isize caps at ~2 GiB, so installing a package larger
+        // than 2 GiB fails with "memory map length overflows isize". Shipping a 64-bit Setup.exe lifts that.
+        var setupPath = Path.Combine(tmpReleaseDir, $"{id}-win-Setup.exe");
+        Assert.True(File.Exists(setupPath), "Expected Setup.exe in the release dir");
+        AssertMachineType(setupPath, expectedMachineType);
+#endif
+    }
+
+#if !DEBUG
+    private void AssertMachineType(string pePath, AsmResolver.PE.File.MachineType expected)
+    {
+        var actual = AsmResolver.PE.PEImage.FromFile(pePath).MachineType;
+        _output.WriteLine($"{Path.GetFileName(pePath)} machine type: {actual}, expected: {expected}");
+        Assert.Equal(expected, actual);
+    }
+#endif
 }


### PR DESCRIPTION
## Problem

Velopack's Windows `Setup.exe` is built 32-bit (i686). It memory-maps its embedded package
to extract, and a 32-bit process caps `isize` at ~2 GiB, so installing any package larger
than 2 GiB fails with **`memory map length overflows isize`**.

CI already compiles the 64-bit (and arm64) binaries — `setup_x64.exe`, `update_x64.exe`,
`stub_x64.exe` — but the C# packaging path hardcodes the x86 binaries for all Windows
targets and never ships the x64/arm64 ones in the NuGet `vendor` folder. So `vpk pack`
always embeds the 32-bit `Setup.exe`, even for a `win-x64` app.

## Related

- **#704** added arch-aware selection for the **updater** (`Update.exe`) but deliberately
  left `Setup.exe`/`Stub` at x86 (it only packed/selected `SetupWin_x86.exe` / `StubWin_x86.exe`),
  and was closed as obsolete to be "revisited as part of #33". This PR is that revisit: it
  completes the deferred bundling work **and extends it to `Setup.exe` and the stub**, which
  is the part that actually enables installing >2 GiB packages. Binary naming follows the
  current `develop` CI convention (`setup_x64.exe`, `update_x64.exe`, `stub_x64.exe`) rather
  than #704's `*Win_x64` names, since `develop`'s `build-rust.yml` already emits the former.
- **#33** fixed the *pack-time* large-file overflow (the `(long)` cast in `SetupBundle`).
  This PR is the *install-time* counterpart — together they let large (>2 GiB) apps both
  pack and install.

## Change

Wire binary selection to the target architecture (Release only; DEBUG keeps the single
host-built binaries):

- **`HelperFile.cs`** — make `GetUpdateExeName` arch-aware on Windows; replace the
  `SetupPath`/`StubExecutablePath` properties with `GetSetupPath(RID)` /
  `GetStubExecutablePath(RID)` methods that select by arch.
- **`WindowsPackCommandRunner.cs`** — pass `Options.TargetRuntime` to the new methods at
  the two call sites (`CreateSetupPackage`, `CreateExecutableStubForExe`).
- **`Directory.Build.targets`** — pack the x64/arm64 `setup`/`update`/`stub` binaries into
  the `vendor` folder so `FindHelperFile` can locate them.

arm64 is wired up too, as a natural extension — x64 is the motivating case.

## API change (please confirm acceptable)

`HelperFile.SetupPath` and `HelperFile.StubExecutablePath` change from **properties to
methods** (`GetSetupPath(RID)` / `GetStubExecutablePath(RID)`), since binary choice now
depends on the target arch. `HelperFile` is `public static`, so this is technically a
source/binary break. Both members had exactly one caller each, both in-tree (in
`WindowsPackCommandRunner`), and updated here. If you consider these part of the stable
public surface, I'm happy to keep the old properties as `[Obsolete]` shims returning the
x86 binaries instead — let me know your preference.

## Fallback behavior

For `RuntimeCpu.x86` / `Unknown`, the new `switch` arms intentionally fall back to the
existing 32-bit binaries — no behavior change for those targets. (Only the Windows/x64
and arm64 paths are new.)

## Test

`WindowsPackTests.PackIncludesCorrectArchitectureBinaries` (x86/x64/arm64) packs for each
target arch and uses `PEImage.MachineType` to assert that **both** the shipped `Update.exe`
(packaged as `Squirrel.exe`) **and** the generated `Setup.exe` match the target
architecture. Release-only — DEBUG uses the single host-built binaries, so the test skips
there.

## Verification status

- ✅ **Build/packaging:** `Velopack.Packaging.Windows` and the test project build in Release
  with 0 warnings/errors; the packed `vpk` `vendor/` contains `setup_x64.exe` with PE
  machine type `Amd64` (vs `setup.exe` = `I386`).
- ✅ **End-to-end:** packed a **~2.5 GiB** Windows x64 app with the patched `vpk` and
  installed it successfully on Windows x64. The same package fails with
  `memory map length overflows isize` using the stock 32-bit `Setup.exe`, confirming the
  64-bit bootstrapper is what removes the limit.

## Known limitation: MSI still blocked for >2 GiB (out of scope)

This PR fixes the **`Setup.exe`** install path only. The `--msi` output is still capped:
`vpk` embeds `Setup.exe` as a single WiX stream, and Windows Installer limits a single
embedded file to <2 GiB (`LGHT0263`), so `--msi` cannot produce a working installer for a
>2 GiB package even with the 64-bit `Setup.exe`. Removing that wall would need a different
MSI shape (e.g. a thin/launcher MSI that invokes `Setup.exe` rather than embedding it),
which is outside the scope of this change — flagging it as a known open issue.

## CI / packaging notes

- The x64/arm64 binaries already exist in CI (`build-rust.yml`) and are staged into
  `target/release` before packing — `build-packages.yml` downloads all `rust-*` artifacts
  there, then runs `dotnet build -c Release /p:PackRustAssets=true` — so the new
  `Directory.Build.targets` entries resolve.
- Out of scope here: the next size wall is the Rust `zip` crate needing zip64 for single
  archives larger than 4 GiB.
