### PR TITLE
Add HttpSource request timeout

### DIFF
--- a/src/lib-python/src/sources.rs
+++ b/src/lib-python/src/sources.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use std::time::Duration;
 use velopack::sources::{AutoSource, GiteaSource, GithubSource, GitlabSource, HttpSource, UpdateSource};
 
 /// Retrieves available releases from a GitHub repository. Supports both github.com
@@ -92,15 +93,17 @@ impl PyGiteaSource {
 #[derive(Clone)]
 pub struct PyHttpSource {
     pub url: String,
+    pub timeout_seconds: Option<u64>,
 }
 
 #[cfg_attr(feature = "stub-gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl PyHttpSource {
-    /// Create a new HttpSource with the specified base URL.
+    /// Create a new HttpSource with the specified base URL and optional request timeout.
     #[new]
-    pub fn new(url: String) -> Self {
-        PyHttpSource { url }
+    #[pyo3(signature = (url, timeout_seconds = None))]
+    pub fn new(url: String, timeout_seconds: Option<u64>) -> Self {
+        PyHttpSource { url, timeout_seconds }
     }
 }
 
@@ -121,7 +124,14 @@ impl PySourceArg {
             PySourceArg::Github(s) => Box::new(GithubSource::new(&s.repo_url, s.access_token, s.prerelease)),
             PySourceArg::Gitlab(s) => Box::new(GitlabSource::new(&s.repo_url, s.access_token, s.prerelease)),
             PySourceArg::Gitea(s) => Box::new(GiteaSource::new(&s.repo_url, s.access_token, s.prerelease)),
-            PySourceArg::Http(s) => Box::new(HttpSource::new(&s.url)),
+            PySourceArg::Http(s) => {
+                let source = if let Some(timeout_seconds) = s.timeout_seconds {
+                    HttpSource::new_with_timeout(&s.url, Duration::from_secs(timeout_seconds))
+                } else {
+                    HttpSource::new(&s.url)
+                };
+                Box::new(source)
+            }
             PySourceArg::Auto(s) => Box::new(AutoSource::new(&s)),
         }
     }

--- a/src/lib-python/velopack.pyi
+++ b/src/lib-python/velopack.pyi
@@ -109,9 +109,9 @@ class HttpSource:
     r"""
     Retrieves updates from a static file host or other web server.
     """
-    def __new__(cls, url: builtins.str) -> HttpSource:
+    def __new__(cls, url: builtins.str, timeout_seconds: typing.Optional[builtins.int] = None) -> HttpSource:
         r"""
-        Create a new HttpSource with the specified base URL.
+        Create a new HttpSource with the specified base URL and optional request timeout.
         """
 
 @typing.final

--- a/src/lib-rust/src/download.rs
+++ b/src/lib-rust/src/download.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use crate::{misc, Error};
 
@@ -13,12 +14,26 @@ where
 }
 
 /// Downloads a file from a URL with custom headers and writes it to a file while reporting progress from 0-100.
-pub fn download_url_to_file_with_headers<A, S: AsRef<Path>>(url: &str, file_path: S, headers: &[(&str, &str)], mut progress: A) -> Result<(), Error>
+pub fn download_url_to_file_with_headers<A, S: AsRef<Path>>(url: &str, file_path: S, headers: &[(&str, &str)], progress: A) -> Result<(), Error>
+where
+    A: FnMut(i16),
+{
+    download_url_to_file_with_headers_and_timeout(url, file_path, headers, None, progress)
+}
+
+/// Downloads a file from a URL with custom headers, an optional timeout, and progress reporting from 0-100.
+pub fn download_url_to_file_with_headers_and_timeout<A, S: AsRef<Path>>(
+    url: &str,
+    file_path: S,
+    headers: &[(&str, &str)],
+    timeout: Option<Duration>,
+    mut progress: A,
+) -> Result<(), Error>
 where
     A: FnMut(i16),
 {
     let file_path = file_path.as_ref();
-    let agent = get_download_agent()?;
+    let agent = get_download_agent(timeout)?;
     let mut req = agent.get(url);
     for &(name, value) in headers {
         req = req.header(name, value);
@@ -63,7 +78,12 @@ pub fn download_url_as_string(url: &str) -> Result<String, Error> {
 
 /// Downloads a file from a URL with custom headers and returns it as a string.
 pub fn download_url_as_string_with_headers(url: &str, headers: &[(&str, &str)]) -> Result<String, Error> {
-    let agent = get_download_agent()?;
+    download_url_as_string_with_headers_and_timeout(url, headers, None)
+}
+
+/// Downloads a file from a URL with custom headers and an optional timeout, and returns it as a string.
+pub fn download_url_as_string_with_headers_and_timeout(url: &str, headers: &[(&str, &str)], timeout: Option<Duration>) -> Result<String, Error> {
+    let agent = get_download_agent(timeout)?;
     let mut req = agent.get(url);
     for &(name, value) in headers {
         req = req.header(name, value);
@@ -72,11 +92,15 @@ pub fn download_url_as_string_with_headers(url: &str, headers: &[(&str, &str)]) 
     Ok(r)
 }
 
-fn get_download_agent() -> Result<ureq::Agent, Error> {
+fn get_download_agent(timeout: Option<Duration>) -> Result<ureq::Agent, Error> {
     // let tls_builder = native_tls::TlsConnector::builder();
     // let tls_connector = tls_builder.build()?;
     // Ok(ureq::AgentBuilder::new().tls_connector(tls_connector.into()).build())
-    Ok(ureq::Agent::config_builder().build().into())
+    let mut config = ureq::Agent::config_builder();
+    if let Some(timeout) = timeout {
+        config = config.timeout_global(Some(timeout));
+    }
+    Ok(config.build().into())
 }
 
 #[test]

--- a/src/lib-rust/src/sources/http.rs
+++ b/src/lib-rust/src/sources/http.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::mpsc::Sender};
+use std::{path::Path, sync::mpsc::Sender, time::Duration};
 
 use crate::bundle::Manifest;
 use crate::*;
@@ -11,6 +11,7 @@ use super::UpdateSource;
 /// and provides query parameters to specify the name of the requested package.
 pub struct HttpSource {
     url: String,
+    timeout: Option<Duration>,
 }
 
 impl HttpSource {
@@ -18,7 +19,19 @@ impl HttpSource {
     pub fn new<S: AsRef<str>>(url: S) -> HttpSource {
         HttpSource {
             url: url.as_ref().to_owned(),
+            timeout: None,
         }
+    }
+
+    /// Create a new HttpSource with the specified base URL and request timeout.
+    pub fn new_with_timeout<S: AsRef<str>>(url: S, timeout: Duration) -> HttpSource {
+        HttpSource::new(url).with_timeout(timeout)
+    }
+
+    /// Sets the request timeout used when fetching release feeds and downloading packages.
+    pub fn with_timeout(mut self, timeout: Duration) -> HttpSource {
+        self.timeout = Some(timeout);
+        self
     }
 }
 
@@ -34,7 +47,7 @@ impl UpdateSource for HttpSource {
         ));
 
         info!("Downloading releases for channel {} from: {}", channel, releases_url);
-        let json = download::download_url_as_string(releases_url.as_str())?;
+        let json = download::download_url_as_string_with_headers_and_timeout(releases_url.as_str(), &[], self.timeout)?;
         let feed: VelopackAssetFeed = serde_json::from_str(&json)?;
         Ok(feed)
     }
@@ -45,7 +58,7 @@ impl UpdateSource for HttpSource {
         let asset_url = url.join(&asset.FileName)?;
 
         info!("About to download from URL '{}' to file '{:?}'", asset_url, local_file);
-        download::download_url_to_file(asset_url.as_str(), local_file, move |p| {
+        download::download_url_to_file_with_headers_and_timeout(asset_url.as_str(), local_file, &[], self.timeout, move |p| {
             if let Some(progress_sender) = &progress_sender {
                 let _ = progress_sender.send(p);
             }

--- a/src/lib-rust/tests/source_http.rs
+++ b/src/lib-rust/tests/source_http.rs
@@ -2,7 +2,27 @@ mod common;
 
 use common::*;
 use std::sync::mpsc;
+use std::time::{Duration, Instant};
 use velopack::sources::{HttpSource, UpdateSource};
+
+fn hanging_server_url(delay: Duration) -> String {
+    use std::io::Read;
+    use std::net::TcpListener;
+    use std::thread;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = stream.read(&mut buffer);
+            thread::sleep(delay);
+        }
+    });
+
+    format!("http://{}", addr)
+}
 
 #[test]
 fn feed_success() {
@@ -36,6 +56,31 @@ fn feed_server_error() {
     let manifest = test_manifest();
     let result = source.get_release_feed("stable", &manifest, "");
     assert!(result.is_err());
+}
+
+#[test]
+fn feed_timeout_errors() {
+    let source = HttpSource::new_with_timeout(hanging_server_url(Duration::from_secs(2)), Duration::from_millis(100));
+    let manifest = test_manifest();
+    let started = Instant::now();
+    let result = source.get_release_feed("stable", &manifest, "");
+
+    assert!(result.is_err());
+    assert!(started.elapsed() < Duration::from_secs(2), "request did not respect configured timeout");
+}
+
+#[test]
+fn download_timeout_errors() {
+    let source = HttpSource::new_with_timeout(hanging_server_url(Duration::from_secs(2)), Duration::from_millis(100));
+    let asset = sample_asset();
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("downloaded.nupkg");
+    let started = Instant::now();
+    let result = source.download_release_entry(&asset, &dest, None);
+
+    assert!(result.is_err());
+    assert!(started.elapsed() < Duration::from_secs(2), "download did not respect configured timeout");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add optional request timeout support to Rust `HttpSource`.
- Apply the timeout to release feed checks and package downloads.
- Expose the option to Python as `HttpSource(url, timeout_seconds=...)`.

Default behavior is unchanged when no timeout is configured.

## Tests

- Added coverage for feed and download timeout paths.