### PR TITLE
Fix MSI quiet-install default location and bracket escaping in packTitle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ dotnet build -c Release               # Build all .NET projects (Release)
 # Rust
 cargo build                           # Build all Rust workspace members (Debug)
 cargo build --release                  # Build all Rust workspace members (Release)
+cargo bw                              # Alias for `cargo build --features windows` — required on Windows
+                                      # to also build stub.exe/setup.exe (needed by packaging tests)
 ```
 
 ## Test Commands
@@ -30,16 +32,17 @@ cargo build --release                  # Build all Rust workspace members (Relea
 # Run all .NET tests
 dotnet test
 
-# Run a specific test project
-dotnet test test/Velopack.Tests
-dotnet test test/Velopack.CommandLine.Tests
+# Run a specific test project (must use --project)
+dotnet test --project test/Velopack.Tests
+dotnet test --project test/Velopack.CommandLine.Tests
 # Do NOT run all of Velopack.Packaging.Tests — it takes far too long.
-# Instead, run targeted subsets with --filter:
-dotnet test test/Velopack.Packaging.Tests --filter "FullyQualifiedName~MsiTests"
-dotnet test test/Velopack.Packaging.Tests --filter "FullyQualifiedName~MySpecificTest"
+# Instead, run targeted subsets. Tests use xunit v3 on Microsoft.Testing.Platform,
+# so filters go after `--` and use --filter-class / --filter-method with * wildcards
+# (NOT the old VSTest --filter "FullyQualifiedName~..." syntax):
+dotnet test --project test/Velopack.Packaging.Tests -- --filter-class "*MsiTests"
 
 # Run a single test by name
-dotnet test test/Velopack.Tests --filter "FullyQualifiedName~TestMethodName"
+dotnet test --project test/Velopack.Tests -- --filter-method "*TestMethodName*"
 
 # Rust tests
 cargo test

--- a/src/vpk/Velopack.Packaging.Windows/Msi/MsiBuilder.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/MsiBuilder.cs
@@ -91,6 +91,31 @@ public static class MsiBuilder
     public static string SanitizeDirectoryString(string name)
         => string.Join("_", name.Split(Path.GetInvalidPathChars()));
 
+    // In MSI "Formatted" columns (shortcut targets, registry keys/values, etc.), square brackets
+    // delimit property references, so literal brackets must be written as [\[] and [\]].
+    public static string EscapeMsiFormattedString(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        StringBuilder sb = new(value.Length);
+        foreach (var c in value) {
+            switch (c) {
+            case '[':
+                sb.Append(@"[\[]");
+                break;
+            case ']':
+                sb.Append(@"[\]]");
+                break;
+            default:
+                sb.Append(c);
+                break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
     public static string FormatXmlMessage(string message)
     {
         if (string.IsNullOrWhiteSpace(message))

--- a/src/vpk/Velopack.Packaging.Windows/Msi/MsiTemplateData.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/MsiTemplateData.cs
@@ -17,12 +17,16 @@ public class MsiTemplateData
     public string AppId;
     public string AppTitle;
     public string AppTitleSanitized => MsiBuilder.SanitizeDirectoryString(AppTitle);
+    public string AppTitleEscaped => MsiBuilder.EscapeMsiFormattedString(AppTitle);
     public string AppPublisher;
     public string AppPublisherSanitized => MsiBuilder.SanitizeDirectoryString(AppPublisher);
+    public string AppPublisherEscaped => MsiBuilder.EscapeMsiFormattedString(AppPublisher);
+    public string AppPublisherSanitizedEscaped => MsiBuilder.EscapeMsiFormattedString(AppPublisherSanitized);
     public string AppMsiVersion;
     public string AppVersion;
 
     public string StubFileName;
+    public string StubFileNameEscaped => MsiBuilder.EscapeMsiFormattedString(StubFileName);
     public string MainExeFileName;
     public bool DesktopShortcut;
     public bool StartMenuShortcut;

--- a/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
@@ -25,9 +25,9 @@
             <StandardDirectory Id="DesktopFolder">
                 <Component Id="ApplicationDesktopShortcut">
                     <Shortcut Id="ApplicationDesktopShortcut" Name="{{AppTitle}}" Description="[MsiDesktopShortcutDescription]"
-                              Target="[INSTALLFOLDER]{{StubFileName}}" WorkingDirectory="INSTALLFOLDER"/>
+                              Target="[INSTALLFOLDER]{{StubFileNameEscaped}}" WorkingDirectory="INSTALLFOLDER"/>
                     <RemoveFolder Id="CleanUpDesktopShortcut" Directory="INSTALLFOLDER" On="uninstall"/>
-                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitized}}&#92;{{AppId}}.DesktopShortcut"
+                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitizedEscaped}}&#92;{{AppId}}.DesktopShortcut"
                                    Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </StandardDirectory>
@@ -44,10 +44,10 @@
                             Id="ApplicationStartMenuShortcut"
                             Name="{{AppTitle}}"
                             Description="[MsiStartMenuShortcutDescription]"
-                            Target="[INSTALLFOLDER]{{StubFileName}}"
+                            Target="[INSTALLFOLDER]{{StubFileNameEscaped}}"
                             WorkingDirectory="INSTALLFOLDER"/>
                     <RemoveFolder Id="CleanUpStartMenuShortcut" Directory="AppPublisherProgramMenuDir" On="uninstall"/>
-                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitized}}&#92;{{AppId}}.StartMenuShortcut"
+                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitizedEscaped}}&#92;{{AppId}}.StartMenuShortcut"
                                    Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </DirectoryRef>
@@ -61,9 +61,9 @@
                             Id="ApplicationStartMenuRootShortcut"
                             Name="{{AppTitle}}"
                             Description="[MsiStartMenuShortcutDescription]"
-                            Target="[INSTALLFOLDER]{{StubFileName}}"
+                            Target="[INSTALLFOLDER]{{StubFileNameEscaped}}"
                             WorkingDirectory="INSTALLFOLDER"/>
-                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitized}}&#92;{{AppId}}.StartMenuRootShortcut"
+                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitizedEscaped}}&#92;{{AppId}}.StartMenuRootShortcut"
                                    Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </StandardDirectory>
@@ -73,10 +73,10 @@
             <StandardDirectory Id="StartupFolder">
                 <Component Id="ApplicationStartupShortcut">
                     <Shortcut Id="ApplicationStartupShortcut" Name="{{AppTitle}}"
-                              Description="Startup shortcut for {{AppTitle}}"
-                              Target="[INSTALLFOLDER]{{StubFileName}}"
+                              Description="Startup shortcut for {{AppTitleEscaped}}"
+                              Target="[INSTALLFOLDER]{{StubFileNameEscaped}}"
                               WorkingDirectory="INSTALLFOLDER"/>
-                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitized}}&#92;{{AppId}}.StartupShortcut"
+                    <RegistryValue Root="HKMU" Key="Software&#92;{{AppPublisherSanitizedEscaped}}&#92;{{AppId}}.StartupShortcut"
                                    Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </StandardDirectory>
@@ -92,10 +92,10 @@
         <DirectoryRef Id="INSTALLFOLDER">
             <Component Id="ArpRegistration">
                 <RegistryKey Root="HKMU" Key="Software&#92;Microsoft&#92;Windows&#92;CurrentVersion&#92;Uninstall&#92;MSI:{{AppId}}">
-                    <RegistryValue Name="DisplayName" Value="{{AppTitle}}" Type="string"/>
+                    <RegistryValue Name="DisplayName" Value="{{AppTitleEscaped}}" Type="string"/>
                     <RegistryValue Name="DisplayVersion" Value="{{AppVersion}}" Type="string"/>
-                    <RegistryValue Name="DisplayIcon" Value="[INSTALLFOLDER]{{StubFileName}}" Type="string"/>
-                    <RegistryValue Name="Publisher" Value="{{AppPublisher}}" Type="string"/>
+                    <RegistryValue Name="DisplayIcon" Value="[INSTALLFOLDER]{{StubFileNameEscaped}}" Type="string"/>
+                    <RegistryValue Name="Publisher" Value="{{AppPublisherEscaped}}" Type="string"/>
                     <RegistryValue Name="UninstallString" Value="msiexec.exe /x [ProductCode]" Type="string"/>
                     <RegistryValue Name="QuietUninstallString" Value="msiexec.exe /x [ProductCode] /qn" Type="string"/>
                     <RegistryValue Name="InstallLocation" Value="[INSTALLFOLDER]" Type="string"/>
@@ -140,6 +140,27 @@
         <Property Id="VELOPACK_INSTALLDIR" Secure="yes"/>
         <SetProperty Id="INSTALLFOLDER" Value="[VELOPACK_INSTALLDIR]" Before="CostFinalize" Sequence="execute"
                      Condition="VELOPACK_INSTALLDIR"/>
+
+        <!-- Quiet/passive/reduced installs (UILevel < 5) never run the UI publishes that set the
+             default INSTALLFOLDER, which would otherwise resolve to {ROOTDRIVE}\{AppTitle}. Apply
+             the same defaults here: the forced location for single-scope packages; per-user for
+             dual-scope packages unless installing per-machine (ALLUSERS=1). -->
+        {{#if InstallLocationCurrentUserOnly}}
+            <SetProperty Action="SetQuietDefaultInstallFolder" Id="INSTALLFOLDER"
+                         Value="[LocalAppDataFolder][ApplicationFolderName]" Before="CostFinalize" Sequence="execute"
+                         Condition="NOT Installed AND NOT VELOPACK_INSTALLDIR AND UILevel&lt;5"/>
+        {{else if InstallLocationAllUsersOnly}}
+            <SetProperty Action="SetQuietDefaultInstallFolder" Id="INSTALLFOLDER"
+                         Value="{{ProgramFilesFolderName}}[ApplicationFolderName]" Before="CostFinalize" Sequence="execute"
+                         Condition="NOT Installed AND NOT VELOPACK_INSTALLDIR AND UILevel&lt;5"/>
+        {{else}}
+            <SetProperty Action="SetQuietDefaultInstallFolderPerUser" Id="INSTALLFOLDER"
+                         Value="[LocalAppDataFolder][ApplicationFolderName]" Before="CostFinalize" Sequence="execute"
+                         Condition="NOT Installed AND NOT VELOPACK_INSTALLDIR AND UILevel&lt;5 AND NOT ALLUSERS=1"/>
+            <SetProperty Action="SetQuietDefaultInstallFolderPerMachine" Id="INSTALLFOLDER"
+                         Value="{{ProgramFilesFolderName}}[ApplicationFolderName]" Before="CostFinalize" Sequence="execute"
+                         Condition="NOT Installed AND NOT VELOPACK_INSTALLDIR AND UILevel&lt;5 AND ALLUSERS=1"/>
+        {{/if}}
 
         {{#if InstallLocationEither}}
             <WixVariable Id="WixUISupportPerUser" Value="1"/>

--- a/src/wix-dll/src/lib.rs
+++ b/src/wix-dll/src/lib.rs
@@ -224,7 +224,12 @@ fn show_messagebox(title: &str, message: &str, icon: MESSAGEBOX_STYLE) {
 
 #[cfg(debug_assertions)]
 fn show_debug_message(fn_name: &str, message: String) {
-    if std::env::var("CI").is_ok() {
+    // Debug dialogs are opt-in so that automated/local test runs are not interrupted.
+    // Deferred custom actions run in processes spawned by the Windows Installer service and do
+    // not inherit the msiexec client's environment, so to see their dialogs this variable must
+    // be set user-wide (`setx VELOPACK_WIX_DEBUG_DIALOGS 1`), or machine-wide
+    // (`setx /M VELOPACK_WIX_DEBUG_DIALOGS 1`) for non-impersonated actions like CleanupDeferred.
+    if std::env::var("VELOPACK_WIX_DEBUG_DIALOGS").is_err() {
         return;
     }
     let message = format!("{}: {}", fn_name, message);

--- a/test/Velopack.Packaging.Tests/MsiTests.cs
+++ b/test/Velopack.Packaging.Tests/MsiTests.cs
@@ -332,6 +332,125 @@ public class MsiTests
         Assert.Equal("4.5.6.0", msiVersion);
     }
 
+    [Theory]
+    [InlineData(InstallLocation.PerUser)]
+    [InlineData(InstallLocation.PerMachine)]
+    [InlineData(InstallLocation.Either)]
+    public async Task TestPackGeneratesMsiWithQuietDefaultInstallFolder(InstallLocation instLocation)
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+
+        using var logger = _output.BuildLoggerFor<MsiTests>();
+
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+        PathHelper.CopyRustAssetTo(Path.ChangeExtension(exe, ".pdb"), tmpOutput);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = "1.2.3",
+            TargetRuntime = RID.Parse("win-x64"),
+            PackDirectory = tmpOutput,
+            BuildMsi = true,
+            InstLocation = instLocation,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        await runner.Run(options);
+
+        string msiPath = Path.Combine(tmpReleaseDir, $"{id}-win.msi");
+        Assert.True(File.Exists(msiPath));
+
+        // quiet/passive installs don't run the UI publishes which normally set the default
+        // INSTALLFOLDER, so the MSI must contain execute-sequence custom actions applying the
+        // same defaults (#945)
+        const string perUserFolder = "[LocalAppDataFolder][ApplicationFolderName]";
+        const string perMachineFolder = "[ProgramFiles64Folder][ApplicationFolderName]";
+        const string baseCondition = "NOT Installed AND NOT VELOPACK_INSTALLDIR AND UILevel<5";
+
+        (string Action, string Target, string Condition)[] expected = instLocation switch {
+            InstallLocation.PerUser => [("SetQuietDefaultInstallFolder", perUserFolder, baseCondition)],
+            InstallLocation.PerMachine => [("SetQuietDefaultInstallFolder", perMachineFolder, baseCondition)],
+            _ => [
+                ("SetQuietDefaultInstallFolderPerUser", perUserFolder, $"{baseCondition} AND NOT ALLUSERS=1"),
+                ("SetQuietDefaultInstallFolderPerMachine", perMachineFolder, $"{baseCondition} AND ALLUSERS=1"),
+            ],
+        };
+
+        using Database db = new Database(msiPath);
+        foreach (var (action, target, condition) in expected) {
+            var caSource = db.ExecuteScalar($"SELECT `Source` FROM `CustomAction` WHERE `Action` = '{action}'") as string;
+            Assert.Equal("INSTALLFOLDER", caSource);
+            var caTarget = db.ExecuteScalar($"SELECT `Target` FROM `CustomAction` WHERE `Action` = '{action}'") as string;
+            Assert.Equal(target, caTarget);
+            var seqCondition = db.ExecuteScalar($"SELECT `Condition` FROM `InstallExecuteSequence` WHERE `Action` = '{action}'") as string;
+            Assert.Equal(condition, seqCondition);
+        }
+    }
+
+    [Fact]
+    public async Task TestPackGeneratesMsiWithBracketsInTitle()
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+
+        using var logger = _output.BuildLoggerFor<MsiTests>();
+
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+        var title = "BracketApp [Staging]";
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+        PathHelper.CopyRustAssetTo(Path.ChangeExtension(exe, ".pdb"), tmpOutput);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = "1.2.3",
+            PackTitle = title,
+            TargetRuntime = RID.Parse("win-x64"),
+            PackDirectory = tmpOutput,
+            Shortcuts = "Desktop,StartMenuRoot",
+            BuildMsi = true,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        await runner.Run(options);
+
+        string msiPath = Path.Combine(tmpReleaseDir, $"{id}-win.msi");
+        Assert.True(File.Exists(msiPath));
+
+        // in MSI "Formatted" columns, square brackets are property-reference syntax and must be
+        // escaped as [\[] / [\]] or they get stripped, breaking shortcut targets and ARP (#946)
+        const string escapedStub = @"[INSTALLFOLDER]BracketApp [\[]Staging[\]].exe";
+
+        using Database db = new Database(msiPath);
+
+        var shortcutTargets = db.ExecuteStringQuery("SELECT `Target` FROM `Shortcut`");
+        Assert.Equal(2, shortcutTargets.Count);
+        Assert.All(shortcutTargets, t => Assert.Equal(escapedStub, t));
+
+        // shortcut names are Filename columns (not Formatted), brackets must remain literal
+        var shortcutNames = db.ExecuteStringQuery("SELECT `Name` FROM `Shortcut`");
+        Assert.All(shortcutNames, n => Assert.Contains(title, n));
+
+        var displayName = db.ExecuteScalar("SELECT `Value` FROM `Registry` WHERE `Name` = 'DisplayName'") as string;
+        Assert.Equal(@"BracketApp [\[]Staging[\]]", displayName);
+
+        var displayIcon = db.ExecuteScalar("SELECT `Value` FROM `Registry` WHERE `Name` = 'DisplayIcon'") as string;
+        Assert.Equal(escapedStub, displayIcon);
+    }
+
     [Fact]
     public async Task TestMsiPerUserInstallAndUpdate()
     {
@@ -361,9 +480,10 @@ public class MsiTests
             // save a copy before packing v2 overwrites msiPath
             File.Copy(msiPath, v1MsiPath, true);
 
-            // install via msiexec per-user (must pass INSTALLFOLDER for silent installs since UI events don't fire)
+            // install via msiexec per-user. no INSTALLFOLDER is passed on purpose: silent installs
+            // must default to %LocalAppData%\{packId} even though the UI events don't fire (#945)
             logger.Info("TEST: Installing MSI per-user...");
-            RunMsiExec($"/i \"{v1MsiPath}\" /qn INSTALLFOLDER=\"{installDir}\"", logger);
+            RunMsiExec($"/i \"{v1MsiPath}\" /qn", logger);
 
             // verify install
             Assert.True(File.Exists(appPath), $"TestApp.exe not found at {appPath}");
@@ -552,10 +672,10 @@ public class MsiTests
             await PackTestAppWithMsi(id, "1.0.0", "version 1 test", releaseDir, logger, InstallLocation.Either);
             Assert.True(File.Exists(msiPath), $"MSI not found at {msiPath}");
 
-            // install via msiexec with ALLUSERS=1 (per-machine, requires admin)
-            // must pass INSTALLFOLDER for silent installs since UI events don't fire
+            // install via msiexec with ALLUSERS=1 (per-machine, requires admin). no INSTALLFOLDER
+            // is passed on purpose: silent per-machine installs must default to Program Files (#945)
             logger.Info("TEST: Installing MSI per-machine...");
-            RunMsiExec($"/i \"{msiPath}\" /qn ALLUSERS=1 INSTALLFOLDER=\"{installDir}\"", logger);
+            RunMsiExec($"/i \"{msiPath}\" /qn ALLUSERS=1", logger);
 
             // verify install
             Assert.True(File.Exists(appPath), $"TestApp.exe not found at {appPath}");


### PR DESCRIPTION
- Quiet/passive MSI installs (UILevel < 5) never ran the UI publishes that set the default INSTALLFOLDER, so apps installed to {ROOTDRIVE}\{title}. Add execute-sequence SetProperty defaults: the forced location for single-scope packages, and per-user (LocalAppData) for dual-scope packages unless ALLUSERS=1 (fixes #945).
- Square brackets in --packTitle broke MSI shortcut targets, ARP DisplayName/DisplayIcon and shortcut registry keys, because [ ] delimit property references in MSI Formatted columns. Escape them as [\[] / [\]] via MsiBuilder.EscapeMsiFormattedString (fixes #946).
- Make velopack_wix debug MessageBoxes opt-in via VELOPACK_WIX_DEBUG_DIALOGS so local Debug test runs are not interrupted (deferred CAs run in service-spawned processes, so an opt-out env var set by tests could never reach them).
- Update MsiTests: silent installs no longer pass INSTALLFOLDER, new DB-level tests for the quiet-default custom actions and bracket escaping.