### PR TITLE
Add timing logs to diagnose slow update apply on EDR machines (#947)

### DIFF
--- a/src/bins/src/commands/apply_windows_impl.rs
+++ b/src/bins/src/commands/apply_windows_impl.rs
@@ -33,6 +33,17 @@ use velopack::{bundle::load_bundle_from_file, constants, locator::VelopackLocato
 //     Ok(())
 // }
 
+fn remove_temp_dir_timed(path: &PathBuf) {
+    if !path.exists() {
+        return;
+    }
+    let sw = simple_stopwatch::Stopwatch::start_new();
+    match remove_dir_all::remove_dir_all(path) {
+        Ok(()) => info!("Removed temp dir {:?} in {:.0}ms", path, sw.ms()),
+        Err(e) => warn!("Failed to remove temp dir {:?} after {:.0}ms: {}", path, sw.ms(), e),
+    }
+}
+
 pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook_mode: super::HookRunMode) -> Result<VelopackLocator> {
     let root_path = old_locator.get_root_dir();
 
@@ -214,8 +225,8 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook
         // should try and remove the temp dirs before recalculating the shortcuts,
         // because windows may try to use the "Distributed Link Tracking and Object Identifiers (DLT) service"
         // to update the shortcut to point at the temp/renamed location
-        let _ = remove_dir_all::remove_dir_all(&temp_path_new);
-        let _ = remove_dir_all::remove_dir_all(&temp_path_old);
+        remove_temp_dir_timed(&temp_path_new);
+        remove_temp_dir_timed(&temp_path_old);
 
         if !old_locator.get_is_portable() {
             crate::windows::create_or_update_manifest_lnks(&new_locator, Some(old_locator));
@@ -262,8 +273,8 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook
     })();
 
     reporter.close();
-    let _ = remove_dir_all::remove_dir_all(&temp_path_new);
-    let _ = remove_dir_all::remove_dir_all(&temp_path_old);
+    remove_temp_dir_timed(&temp_path_new);
+    remove_temp_dir_timed(&temp_path_old);
     action?;
     Ok(new_locator)
 }

--- a/src/bins/src/shared/util_windows.rs
+++ b/src/bins/src/shared/util_windows.rs
@@ -39,7 +39,11 @@ unsafe fn get_processes_running_in_directory<P: AsRef<Path>>(dir: P) -> Result<V
     let mut full_path_vec = vec![0; i16::MAX as usize];
     let full_path_ptr = PWSTR(full_path_vec.as_mut_ptr());
 
-    for pid in get_pids()? {
+    let sw = simple_stopwatch::Stopwatch::start_new();
+    let pids = get_pids()?;
+    let total_pids = pids.len();
+
+    for pid in pids {
         let process = process::open_process(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, false, pid);
         if process.is_err() {
             continue;
@@ -65,6 +69,12 @@ unsafe fn get_processes_running_in_directory<P: AsRef<Path>>(dir: P) -> Result<V
         }
     }
 
+    info!(
+        "Inspected {} running processes in {:.0}ms, {} matched directory",
+        total_pids,
+        sw.ms(),
+        oup.len()
+    );
     Ok(oup)
 }
 
@@ -87,6 +97,7 @@ fn _force_stop_package<P: AsRef<Path>>(root_dir: P) -> Result<()> {
         warn!("Killing process: {} ({})", path.display(), pid);
         process::kill_process(handle)?;
     }
+    info!("Force-stop check complete.");
     Ok(())
 }
 

--- a/src/bins/src/windows/shortcuts.rs
+++ b/src/bins/src/windows/shortcuts.rs
@@ -412,6 +412,7 @@ where
     T: Send + 'static,
     F: FnOnce() -> Result<T> + Send + 'static,
 {
+    let sw = simple_stopwatch::Stopwatch::start_new();
     let t = std::thread::spawn(move || {
         unsafe {
             let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
@@ -422,6 +423,7 @@ where
             // I don't know why we need it, but if we don't have it then subsequent COM calls
             // will break intermittently.
             std::thread::sleep(Duration::from_millis(1));
+            info!("COM context initialized in {:.0}ms", sw.ms());
             let result = delegate();
             CoUninitialize();
             result


### PR DESCRIPTION
The reporter sees a ~14s unlogged gap between the running-process check and the shortcut update phase. The process scan itself completes before the 'Skipping killing self' line is printed, so the stall must be in one of the unmeasured operations that follow: the temp dir deletions or the COM context initialization. Add elapsed-time logging around each so the next field log can pinpoint the culprit.