### PR TITLE
Fix supply-chain CI: address new RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,11 @@ ignore = [
     { id = "RUSTSEC-2020-0071", reason = "only affects Unix setenv race; not exploitable in our usage" },
     # ttf-parser is unmaintained; pulled in transitively via xdialog -> winit -> sctk-adwaita -> ab_glyph, no replacement available
     { id = "RUSTSEC-2026-0192", reason = "unmaintained transitive dep via xdialog/winit, no drop-in replacement" },
+    # quick-xml DoS advisories only affect parsing of untrusted XML; here quick-xml is used solely by wayland-scanner
+    # at build time to parse trusted local Wayland protocol files (via xdialog -> softbuffer). Latest wayland-scanner
+    # (0.31.10) still pins quick-xml ^0.39, so there is no upgrade path yet. Revisit when upstream bumps quick-xml.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml DoS via wayland-scanner build-time codegen; trusted XML, no upgrade path" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml DoS via wayland-scanner build-time codegen; trusted XML, no upgrade path" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Problem

The `build-tests / supply-chain` job (`cargo deny check`) has been failing on newly-published RUSTSEC advisories:

- **RUSTSEC-2026-0194** / **RUSTSEC-2026-0195** — DoS advisories against `quick-xml 0.39.4` (quadratic attribute checking + unbounded namespace allocation).
- **RUSTSEC-2026-0204** — invalid pointer dereference in `crossbeam-epoch 0.9.18`.

## Fix

**crossbeam-epoch** is a real runtime dependency (`rayon → image → velopack_bins`) and a patch exists, so it's bumped `0.9.18 → 0.9.20`.

**quick-xml** is pulled in **only** transitively via `wayland-scanner → softbuffer → xdialog → velopack_l18n`. `wayland-scanner` uses it at build time to parse the trusted Wayland protocol XML shipped inside the crate — Velopack never feeds it untrusted input, so the DoS attack surface these advisories describe is not reachable. There is also no upgrade path: the fix wants `quick-xml >= 0.41`, but the latest `wayland-scanner` (0.31.10) still pins `quick-xml = "^0.39"`. Both are added to the `deny.toml` ignore list with a documented reason, matching the existing ignore for the same `xdialog/wayland` stack (RUSTSEC-2026-0192). To revisit once upstream bumps quick-xml.

## Verification

`cargo deny check` locally now reports: `advisories ok, bans ok, licenses ok, sources ok`.
