### PR TITLE
Fix portable/MSI launcher renamed after update (packTitle vs mainExe)

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -83,10 +83,13 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
 
         File.Copy(updatePath, Path.Combine(packDir, "Squirrel.exe"), true);
 
-        // create a stub for portable / MSI packages
+        // create a stub for portable / MSI packages. The stub is named after the
+        // final launcher name (packTitle) rather than the main exe, so that when the
+        // updater re-extracts it on update (stripping the "_ExecutionStub" suffix) it
+        // produces the same launcher name that was created at pack time. See #982.
         var mainExeName = Options.EntryExecutableName;
         var mainPath = Path.Combine(packDir, mainExeName);
-        var stubPath = Path.Combine(packDir, Path.GetFileNameWithoutExtension(mainExeName) + "_ExecutionStub.exe");
+        var stubPath = Path.Combine(packDir, GetStubBaseName() + "_ExecutionStub.exe");
         CreateExecutableStubForExe(mainPath, stubPath);
 
         Options.TargetRuntime.Architecture = Options.TargetRuntime.HasArchitecture
@@ -234,7 +237,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
             // move the stub to the root of the MSI package
             var msiStubPath = Path.Combine(
                 current.FullName,
-                Path.GetFileNameWithoutExtension(Options.EntryExecutableName) + "_ExecutionStub.exe");
+                GetStubBaseName() + "_ExecutionStub.exe");
             File.Move(msiStubPath, Path.Combine(dir.FullName, GetStubFileName()));
 
             File.Create(Path.Combine(dir.FullName, ".msi-installed")).Close();
@@ -268,7 +271,7 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         // move the stub to the root of the portable package
         var stubPath = Path.Combine(
             current.FullName,
-            Path.GetFileNameWithoutExtension(Options.EntryExecutableName) + "_ExecutionStub.exe");
+            GetStubBaseName() + "_ExecutionStub.exe");
         File.Move(stubPath, Path.Combine(dir.FullName, GetStubFileName()));
 
         // create a .portable file to indicate this is a portable package
@@ -385,7 +388,12 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
         ];
     }
 
-    private string GetStubFileName() => (Options.PackTitle ?? Options.PackId) + ".exe";
+    // Base name (without extension) for the portable / MSI launcher stub. Kept in sync
+    // with the stub file created inside the package so the updater reproduces the same
+    // launcher name when it strips the "_ExecutionStub" suffix on update. See #982.
+    private string GetStubBaseName() => Options.PackTitle ?? Options.PackId;
+
+    private string GetStubFileName() => GetStubBaseName() + ".exe";
 
     private ShortcutLocation GetShortcuts()
     {

--- a/test/Velopack.Pack.Tests/WindowsPackTests.cs
+++ b/test/Velopack.Pack.Tests/WindowsPackTests.cs
@@ -97,6 +97,61 @@ public class WindowsPackTests
     }
 
     [Fact]
+    public void PortableStubNameMatchesUpdateStubName()
+    {
+        // Regression test for https://github.com/velopack/velopack/issues/982
+        // When --packTitle differs from --mainExe, the portable launcher created at
+        // pack time must have the same name as the launcher the updater re-extracts
+        // from the nupkg on update (nupkg stub with the "_ExecutionStub" suffix
+        // stripped). Otherwise updating leaves two differently-named launchers behind.
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+
+        using var logger = _output.BuildLoggerFor<WindowsPackTests>();
+
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+        using var _3 = TempUtil.GetTempDirectory(out var nupkgDir);
+        using var _4 = TempUtil.GetTempDirectory(out var portableDir);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+        var version = "1.0.0";
+        var title = "Test Squirrel App"; // deliberately different from the main exe name
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = version,
+            TargetRuntime = RID.Parse("win-x64"),
+            PackTitle = title,
+            PackDirectory = tmpOutput,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        runner.Run(options).GetAwaiterResult();
+
+        // The launcher the updater will produce: the "_ExecutionStub.exe" inside the
+        // nupkg, with the suffix stripped (mirrors Bundle.extract_stubs_to_dir in Rust).
+        var nupkgPath = Path.Combine(tmpReleaseDir, $"{id}-{version}-full.nupkg");
+        Assert.True(File.Exists(nupkgPath));
+        EasyZip.ExtractZipToDirectory(logger.ToVelopackLogger(), nupkgPath, nupkgDir);
+        var nupkgStub = Directory.EnumerateFiles(nupkgDir, "*_ExecutionStub.exe", SearchOption.AllDirectories).Single();
+        var updaterLauncherName = Path.GetFileName(nupkgStub).Replace("_ExecutionStub.exe", ".exe");
+
+        // The launcher created at pack time in the portable package root.
+        var portablePath = Directory.EnumerateFiles(tmpReleaseDir, "*-Portable.zip").Single();
+        EasyZip.ExtractZipToDirectory(logger.ToVelopackLogger(), portablePath, portableDir);
+        var portableLauncherName = Directory.EnumerateFiles(portableDir, "*.exe")
+            .Select(Path.GetFileName)
+            .Single(n => !n.Equals("Update.exe", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(portableLauncherName, updaterLauncherName);
+    }
+
+    [Fact]
     public void PackBuildRefuseSameVersion()
     {
         Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");


### PR DESCRIPTION
Fixes #982.

## Problem

On Windows, when `--packTitle` differs from `--mainExe`, applying an update leaves a **second, differently-named launcher** in the portable/MSI root, causing duplicate entry points and breaking shortcuts that targeted the original launcher.

## Root cause

The root launcher and the launcher the updater re-extracts were named from two different sources:

- **At pack time** the portable/MSI root launcher is named `(packTitle ?? packId).exe` (`GetStubFileName()`, and the MSI template's `StubFileName`) — e.g. `My App.exe`.
- **The stub embedded in the `.nupkg`** was named after `mainExe`: `MyApp_ExecutionStub.exe`.
- **On update** the Rust updater's `Bundle::extract_stubs_to_dir` simply strips the `_ExecutionStub` suffix, yielding `MyApp.exe` — a *different* name.

So the launcher created at pack time (`My App.exe`) and the one produced on update (`MyApp.exe`) disagreed whenever the title and main exe names differed.

## Fix

Name the stub embedded in the package after the same base as the final launcher (`packTitle ?? packId`) via a new `GetStubBaseName()` helper. The updater's suffix-strip now reproduces the exact launcher name created at pack time, so updates overwrite the single launcher instead of creating a duplicate. Shortcuts were never affected — they target `current/<mainExe>`, not the root launcher.

## Testing

- Added `PortableStubNameMatchesUpdateStubName`, asserting the invariant *(nupkg stub name minus `_ExecutionStub`) == portable root launcher name*. Verified it failed before the fix (`Expected: "Test Squirrel App.exe"`, `Actual: "testapp.exe"`) and passes after.
- Regression-ran the E2E suite: `PackBuildsPackageWhichIsInstallable` (setup install + shortcuts) and `TestPackedAppCanDeltaUpdateToLatest` (full install + delta update) — both pass.

Note: this corrects packages built with the updated `vpk`. Already-shipped packages can't be retroactively fixed, but once a developer rebuilds with this change the next update converges field installs onto the single correct launcher name.