### PR TITLE
Make Velopack Flow a first-class update source across all client libraries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ copying files into `target/release`.
 ```
 src/
 ├── lib-csharp/          # Core C# library (Velopack NuGet package)
-│   ├── Sources/         # Update sources (GitHub, GitLab, Gitea, S3, Azure, HTTP)
+│   ├── Sources/         # Update sources (Velopack Flow, GitHub, GitLab, Gitea, HTTP, file)
 │   ├── Locators/        # Platform-specific app locators (Windows, Linux, OSX)
 │   ├── NuGet/           # Package handling (ZipPackage, PackageManifest)
 │   └── UpdateManager.cs, VelopackApp.cs  # Primary public API

--- a/src/bins/src/commands/apply_linux_impl.rs
+++ b/src/bins/src/commands/apply_linux_impl.rs
@@ -40,7 +40,7 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
         std::fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o755))?;
 
         reporter.set_indeterminate();
-        info!("Moving temp AppImage to: {}", &appimage_path);
+        info!("Moving temp AppImage to: {}", appimage_path);
         // we use mv instead of fs::rename / fs::copy because rename fails cross-device
         // and copy fails if the process is running (presumably because rust opens the file for writing)
         // while mv works in both cases.
@@ -48,7 +48,7 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
         let mv_output = Command::new("mv").args(mv_args).output()?;
 
         if mv_output.status.success() {
-            info!("AppImage moved successfully to: {}", &appimage_path);
+            info!("AppImage moved successfully to: {}", appimage_path);
             return Ok(());
         }
 
@@ -58,7 +58,7 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
             mv_output
         );
         dialogs::ask_user_to_elevate(&manifest.title, &manifest.version.to_string())?;
-        let script = format!("#!/bin/sh\nmv -f '{}' '{}'", temp_path, &appimage_path);
+        let script = format!("#!/bin/sh\nmv -f '{}' '{}'", temp_path, appimage_path);
         info!("Writing script for elevation: \n{}", script);
         fs::write(&script_path, script)?;
         std::fs::set_permissions(
@@ -69,7 +69,7 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
         info!("Attempting to elevate: pkexec {:?}", args);
         let elev_output = Command::new("pkexec").args(args).output()?;
         if elev_output.status.success() {
-            info!("AppImage moved (elevated) to {}", &appimage_path);
+            info!("AppImage moved (elevated) to {}", appimage_path);
             Ok(())
         } else {
             bail!("pkexec failed with status: {:?}", elev_output);

--- a/src/bins/src/commands/apply_osx_impl.rs
+++ b/src/bins/src/commands/apply_osx_impl.rs
@@ -72,20 +72,20 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
     let action: Result<()> = (|| {
         // 1. extract the bundle to a temp dir
         fs::create_dir_all(&tmp_path_new)?;
-        info!("Extracting bundle to {:?}", &tmp_path_new);
+        info!("Extracting bundle to {:?}", tmp_path_new);
         bundle.extract_lib_contents_to_path(&tmp_path_new, |p| reporter.set_progress(p))?;
 
         // 2. attempt to replace the current bundle with the new one
         reporter.set_indeterminate();
         let result: Result<()> = (|| {
-            info!("Replacing bundle at {:?}", &root_path);
+            info!("Replacing bundle at {:?}", root_path);
             replace_bundle(&root_path, &tmp_path_old, &tmp_path_new)?;
             Ok(())
         })();
 
         let result = match result {
             Ok(()) => {
-                info!("Bundle extracted successfully to {:?}", &root_path);
+                info!("Bundle extracted successfully to {:?}", root_path);
                 Ok(())
             }
             Err(e) => {

--- a/src/bins/src/commands/apply_windows_impl.rs
+++ b/src/bins/src/commands/apply_windows_impl.rs
@@ -158,7 +158,7 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook
         // third, we try _REALLY HARD_ to stop the package
         let _ = shared::force_stop_package(&root_path);
         // fourth, we make as backup of the current dir to temp_path_old
-        info!("Backing up current dir to {:?}", &temp_path_old);
+        info!("Backing up current dir to {:?}", temp_path_old);
         shared::retry_io_ex(|| fs::rename(&current_dir, &temp_path_old), 1000, 10)
             .context("Unable to start the update, because one or more running processes prevented it. Try again later, or if the issue persists, restart your computer.")?;
 
@@ -171,7 +171,7 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook
 
         // fifth, we try to replace the current dir with temp_path_new
         // if this fails we will yolo a rollback...
-        info!("Replacing current dir with {:?}", &temp_path_new);
+        info!("Replacing current dir with {:?}", temp_path_new);
         shared::retry_io_ex(|| fs::rename(&temp_path_new, &current_dir), 1000, 30).context(
             "Unable to complete the update, and the app was left in a broken state. You may need to re-install or repair this application manually.",
         )?;
@@ -249,7 +249,7 @@ pub fn apply_package_impl(old_locator: &VelopackLocator, package: &PathBuf, hook
             same_file::is_same_file(default_update_exe, &current_update_exe),
         ) {
             (true, Ok(true)) => {
-                info!("Update.exe is already in the correct location: {:?}", &current_update_exe);
+                info!("Update.exe is already in the correct location: {:?}", current_update_exe);
             }
             (false, _) | (_, Ok(false)) => {
                 info!(

--- a/src/bins/src/commands/install.rs
+++ b/src/bins/src/commands/install.rs
@@ -15,24 +15,19 @@ use std::{
 
 /// Installs the given package. If `channel_override` is set, the installed manifest's `<channel>`
 /// is rewritten to it before any hooks run or the app is launched.
-pub fn install(
-    pkg: &mut BundleZip,
-    install_to: Option<&PathBuf>,
-    start_args: Option<Vec<OsString>>,
-    channel_override: Option<&str>,
-) -> Result<()> {
+pub fn install(pkg: &mut BundleZip, install_to: Option<&PathBuf>, start_args: Option<Vec<OsString>>, channel_override: Option<&str>) -> Result<()> {
     // find and parse nuspec
     info!("Reading package manifest...");
     let app = pkg.read_manifest()?;
 
     info!("Package manifest loaded successfully.");
-    info!("    Package ID: {}", &app.id);
-    info!("    Package Version: {}", &app.version);
-    info!("    Package Title: {}", &app.title);
-    info!("    Package Authors: {}", &app.authors);
-    info!("    Package Description: {}", &app.description);
-    info!("    Package Machine Architecture: {}", &app.machine_architecture);
-    info!("    Package Runtime Dependencies: {}", &app.runtime_dependencies);
+    info!("    Package ID: {}", app.id);
+    info!("    Package Version: {}", app.version);
+    info!("    Package Title: {}", app.title);
+    info!("    Package Authors: {}", app.authors);
+    info!("    Package Description: {}", app.description);
+    info!("    Package Machine Architecture: {}", app.machine_architecture);
+    info!("    Package Runtime Dependencies: {}", app.runtime_dependencies);
 
     if !windows::prerequisite::prompt_and_install_all_missing(&app.title, &app.version.to_string(), &app.runtime_dependencies, None)? {
         info!("Cancelling setup. Pre-requisites not installed.");

--- a/src/bins/src/update.rs
+++ b/src/bins/src/update.rs
@@ -196,7 +196,7 @@ fn main_inner() -> Result<()> {
     info!("    Silent: {}", silent);
     info!("    Root Directory: {:?}", root_dir);
     info!("    Log File: {:?}", desired_log_file);
-    info!("    Context: {:?}", &location_context);
+    info!("    Context: {:?}", location_context);
 
     let (subcommand, subcommand_matches) = matches
         .subcommand()

--- a/src/lib-cpp/include/Velopack.h
+++ b/src/lib-cpp/include/Velopack.h
@@ -352,6 +352,18 @@ bool vpkc_new_update_manager(const char *psz_url_or_path,
                              vpkc_update_manager_t **p_manager);
 
 /**
+ * Create a new UpdateManager instance which retrieves updates from the hosted Velopack Flow service (https://velopack.io).
+ * This is a convenience function which is equivalent to creating a VelopackFlowSource and calling vpkc_new_update_manager_with_source.
+ * @param p_options Optional extra configuration for update manager.
+ * @param p_locator Optional explicit path configuration for Velopack. If null, the default locator will be used.
+ * @param p_manager A pointer to where the new vpkc_update_manager_t* instance will be stored.
+ * @returns True if the update manager was created successfully, false otherwise. If false, the error will be available via `vpkc_get_last_error`.
+ */
+bool vpkc_new_update_manager_flow(struct vpkc_update_options_t *p_options,
+                                  struct vpkc_locator_config_t *p_locator,
+                                  vpkc_update_manager_t **p_manager);
+
+/**
  * Create a new UpdateManager instance with a custom UpdateSource.
  * @param p_source A pointer to a custom UpdateSource.
  * @param p_options Optional extra configuration for update manager.

--- a/src/lib-cpp/include/Velopack.hpp
+++ b/src/lib-cpp/include/Velopack.hpp
@@ -974,6 +974,23 @@ public:
     };
 
     /**
+     * Create a new UpdateManager instance which retrieves updates from the hosted Velopack Flow service (https://velopack.io).
+     * This is a convenience constructor equivalent to creating a VelopackFlowSource and passing it to UpdateManager.
+     * @param options Optional extra configuration for update manager.
+     * @param locator Override the default locator configuration (usually used for testing / mocks).
+     */
+    UpdateManager(const UpdateOptions* options = nullptr, const VelopackLocatorConfig* locator = nullptr) {
+        vpkc_update_options_t* pOptions = alloc_c_UpdateOptions_ptr(options);
+        vpkc_locator_config_t* pLocator = alloc_c_VelopackLocatorConfig_ptr(locator);
+        bool result = vpkc_new_update_manager_flow(pOptions, pLocator, &m_pManager);
+        free_c_UpdateOptions(pOptions);
+        free_c_VelopackLocatorConfig(pLocator);
+        if (!result) {
+            throw_last_error();
+        }
+    };
+
+    /**
      * Destructor for UpdateManager.
      */
     ~UpdateManager() {

--- a/src/lib-cpp/src/lib.rs
+++ b/src/lib-cpp/src/lib.rs
@@ -250,6 +250,29 @@ pub extern "C" fn vpkc_new_update_manager(
     })
 }
 
+/// Create a new UpdateManager instance which retrieves updates from the hosted Velopack Flow service (https://velopack.io).
+/// This is a convenience function which is equivalent to creating a VelopackFlowSource and calling vpkc_new_update_manager_with_source.
+/// @param p_options Optional extra configuration for update manager.
+/// @param p_locator Optional explicit path configuration for Velopack. If null, the default locator will be used.
+/// @param p_manager A pointer to where the new vpkc_update_manager_t* instance will be stored.
+/// @returns True if the update manager was created successfully, false otherwise. If false, the error will be available via `vpkc_get_last_error`.
+#[no_mangle]
+#[logfn(Trace)]
+#[logfn_inputs(Trace)]
+pub extern "C" fn vpkc_new_update_manager_flow(
+    p_options: *mut vpkc_update_options_t,
+    p_locator: *mut vpkc_locator_config_t,
+    p_manager: *mut *mut vpkc_update_manager_t,
+) -> bool {
+    wrap_error(|| {
+        let options = c_to_UpdateOptions(p_options).ok();
+        let locator = c_to_VelopackLocatorConfig(p_locator).ok();
+        let manager = UpdateManager::new_flow(options, locator)?;
+        unsafe { *p_manager = UpdateManagerRawPtr::new(manager) };
+        Ok(())
+    })
+}
+
 /// Create a new UpdateManager instance with a custom UpdateSource.
 /// @param p_source A pointer to a custom UpdateSource.
 /// @param p_options Optional extra configuration for update manager.
@@ -816,5 +839,52 @@ mod tests {
         assert!(roundtripped.DeltasToTarget.is_empty());
 
         unsafe { free_UpdateInfo(c_update) };
+    }
+
+    #[test]
+    fn new_update_manager_flow_uses_flow_source() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root_dir = temp_dir.path().join("root");
+        let packages_dir = root_dir.join("packages");
+        let current_binary_dir = root_dir.join("current");
+        let update_exe_path = root_dir.join("Update.exe");
+
+        std::fs::create_dir_all(&packages_dir).unwrap();
+        std::fs::create_dir_all(&current_binary_dir).unwrap();
+        std::fs::write(&update_exe_path, []).unwrap();
+
+        let manifest_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("test")
+            .join("fixtures")
+            .join("Test.Squirrel-App.nuspec");
+
+        let locator = velopack::locator::VelopackLocatorConfig {
+            RootAppDir: root_dir,
+            UpdateExePath: update_exe_path,
+            PackagesDir: packages_dir,
+            ManifestPath: manifest_path,
+            CurrentBinaryDir: current_binary_dir,
+            IsPortable: true,
+        };
+
+        let c_locator = unsafe { allocate_VelopackLocatorConfig(&locator) };
+        assert!(!c_locator.is_null());
+
+        let mut manager: *mut vpkc_update_manager_t = ptr::null_mut();
+        let ok = vpkc_new_update_manager_flow(ptr::null_mut(), c_locator, &mut manager);
+        unsafe { free_VelopackLocatorConfig(c_locator) };
+
+        assert!(ok, "vpkc_new_update_manager_flow failed: {}", get_last_error());
+        assert!(!manager.is_null());
+
+        let mut buf = [0 as c_char; 256];
+        let written = vpkc_get_app_id(manager, buf.as_mut_ptr(), buf.len());
+        assert!(written > 0);
+        let app_id = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }.to_string_lossy().to_string();
+        assert_eq!(app_id, "Test.Squirrel-App");
+
+        vpkc_free_update_manager(manager);
     }
 }

--- a/src/lib-csharp/UpdateManager.cs
+++ b/src/lib-csharp/UpdateManager.cs
@@ -73,11 +73,22 @@ namespace Velopack
         protected int MaximumDeltasBeforeFallback { get; }
 
         /// <summary>
+        /// Creates a new UpdateManager instance which checks for updates using the Velopack Flow service (see <see cref="VelopackFlowSource"/>).
+        /// </summary>
+        /// <param name="options">Override / configure default update behaviors.</param>
+        /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths.
+        /// For example, if you wanted to test that updates are working in a unit test, you could provide an instance of <see cref="TestVelopackLocator"/>. </param>
+        public UpdateManager(UpdateOptions? options = null, IVelopackLocator? locator = null)
+            : this(new VelopackFlowSource(), options, locator)
+        {
+        }
+
+        /// <summary>
         /// Creates a new UpdateManager instance using the specified URL or file path to the releases feed, and the specified channel name.
         /// </summary>
         /// <param name="urlOrPath">A basic URL or file path to use when checking for updates.</param>
         /// <param name="options">Override / configure default update behaviors.</param>
-        /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths. 
+        /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths.
         /// For example, if you wanted to test that updates are working in a unit test, you could provide an instance of <see cref="TestVelopackLocator"/>. </param>
         public UpdateManager(string urlOrPath, UpdateOptions? options = null, IVelopackLocator? locator = null)
             : this(CreateSimpleSource(urlOrPath), options, locator)
@@ -88,7 +99,7 @@ namespace Velopack
         /// Creates a new UpdateManager instance using the specified URL or file path to the releases feed, and the specified channel name.
         /// </summary>
         /// <param name="source">The source describing where to search for updates. This can be a custom source, if you are integrating with some private resource,
-        /// or it could be one of the predefined sources. (eg. <see cref="SimpleWebSource"/> or <see cref="GithubSource"/>, etc).</param>
+        /// or it could be one of the predefined sources. (eg. <see cref="VelopackFlowSource"/>, <see cref="SimpleWebSource"/> or <see cref="GithubSource"/>, etc).</param>
         /// <param name="options">Override / configure default update behaviors.</param>
         /// <param name="locator">This should usually be left null. Providing an <see cref="IVelopackLocator" /> allows you to mock up certain application paths. 
         /// For example, if you wanted to test that updates are working in a unit test, you could provide an instance of <see cref="TestVelopackLocator"/>. </param>

--- a/src/lib-nodejs/src/index.ts
+++ b/src/lib-nodejs/src/index.ts
@@ -5,7 +5,7 @@ export { HttpHeader, HttpOptions, UpdateInfo, UpdateOptions, VelopackLocatorConf
 
 type UpdateManagerOpaque = {};
 declare module "./load" {
-  function js_new_update_manager(source: string, options: string | null, locator: string | null): UpdateManagerOpaque;
+  function js_new_update_manager(source: string | null, options: string | null, locator: string | null): UpdateManagerOpaque;
 
   function js_get_current_version(um: UpdateManagerOpaque): string;
 
@@ -245,11 +245,22 @@ export class GiteaSource {
 }
 
 /**
+ * Retrieves updates from the hosted Velopack Flow service (https://api.velopack.io/).
+ */
+export class VelopackFlowSource {
+  /**
+   * Create a new VelopackFlowSource.
+   * @param baseUri Optional base URI of the Velopack Flow service. Defaults to the hosted service (https://api.velopack.io/).
+   */
+  constructor(public readonly baseUri?: string) {}
+}
+
+/**
  * A source that UpdateManager can retrieve updates from. A plain string is auto-detected:
  * a local path uses FileSource, a github.com/gitlab.com/gitea.com URL uses the matching
  * git source, and any other URL uses HttpSource.
  */
-export type UpdateSource = string | FileSource | HttpSource | GithubSource | GitlabSource | GiteaSource;
+export type UpdateSource = string | FileSource | HttpSource | GithubSource | GitlabSource | GiteaSource | VelopackFlowSource;
 
 function serializeSource(source: UpdateSource): string {
   if (typeof source === "string") {
@@ -283,6 +294,11 @@ function serializeSource(source: UpdateSource): string {
       accessToken: source.accessToken,
       prerelease: source.prerelease,
     });
+  } else if (source instanceof VelopackFlowSource) {
+    return JSON.stringify({
+      kind: "flow",
+      baseUri: source.baseUri,
+    });
   }
   throw new Error("Unsupported update source type");
 }
@@ -294,17 +310,52 @@ export class UpdateManager {
   private readonly opaque: UpdateManagerOpaque;
 
   /**
+   * Create a new UpdateManager instance that retrieves updates from the hosted Velopack Flow service.
+   * @param options Optional extra configuration for update manager.
+   * @param locator Override the default locator configuration (usually used for testing / mocks).
+   */
+  constructor(options?: UpdateOptions, locator?: VelopackLocatorConfig);
+  /**
    * Create a new UpdateManager instance.
    * @param source The source to check for updates: one of the update source classes, or a
    * URL / local path string which will be auto-detected.
    * @param options Optional extra configuration for update manager.
    * @param locator Override the default locator configuration (usually used for testing / mocks).
    */
-  constructor(source: UpdateSource, options?: UpdateOptions, locator?: VelopackLocatorConfig) {
+  constructor(source: UpdateSource, options?: UpdateOptions, locator?: VelopackLocatorConfig);
+  constructor(
+    sourceOrOptions?: UpdateSource | UpdateOptions,
+    optionsOrLocator?: UpdateOptions | VelopackLocatorConfig,
+    locator?: VelopackLocatorConfig,
+  ) {
+    const firstIsSource =
+      typeof sourceOrOptions === "string" ||
+      sourceOrOptions instanceof FileSource ||
+      sourceOrOptions instanceof HttpSource ||
+      sourceOrOptions instanceof GithubSource ||
+      sourceOrOptions instanceof GitlabSource ||
+      sourceOrOptions instanceof GiteaSource ||
+      sourceOrOptions instanceof VelopackFlowSource;
+
+    let source: UpdateSource | null;
+    let options: UpdateOptions | undefined;
+    let resolvedLocator: VelopackLocatorConfig | undefined;
+
+    if (firstIsSource) {
+      source = sourceOrOptions as UpdateSource;
+      options = optionsOrLocator as UpdateOptions | undefined;
+      resolvedLocator = locator;
+    } else {
+      // No explicit source: updates come from the hosted Velopack Flow service.
+      source = null;
+      options = sourceOrOptions as UpdateOptions | undefined;
+      resolvedLocator = optionsOrLocator as VelopackLocatorConfig | undefined;
+    }
+
     this.opaque = addon.js_new_update_manager(
-      serializeSource(source),
+      source !== null ? serializeSource(source) : null,
       options ? JSON.stringify(options) : "",
-      locator ? JSON.stringify(locator) : null,
+      resolvedLocator ? JSON.stringify(resolvedLocator) : null,
     );
   }
 

--- a/src/lib-nodejs/test/UpdateManager.test.ts
+++ b/src/lib-nodejs/test/UpdateManager.test.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, existsSync, readFileSync } from "fs";
 import http from "http";
 import { AddressInfo } from "net";
-import { FileSource, HttpSource, UpdateManager, UpdateOptions, VelopackApp, VelopackLocatorConfig } from "../src";
+import { FileSource, HttpSource, UpdateManager, UpdateOptions, VelopackApp, VelopackFlowSource, VelopackLocatorConfig } from "../src";
 import path from "path";
 import { tempd3, fixture, updateExe } from "./helper";
 
@@ -134,5 +134,51 @@ test("UpdateManager downloads full update", async () => {
     await um.downloadUpdateAsync(update!, () => {});
 
     expect(existsSync(path.join(packagesDir, "AvaloniaCrossPlat-1.0.11-full.nupkg"))).toBe(true);
+  });
+});
+
+test("UpdateManager defaults to Velopack Flow when no source is given", async () => {
+  await tempd3(async (_tmpDir, packagesDir, rootDir) => {
+    const locator: VelopackLocatorConfig = {
+      ManifestPath: "../../test/fixtures/Test.Squirrel-App.nuspec",
+      PackagesDir: packagesDir,
+      RootAppDir: rootDir,
+      UpdateExePath: updateExe(),
+      CurrentBinaryDir: path.join(rootDir, "current"),
+      IsPortable: true,
+    };
+
+    const options: UpdateOptions = {
+      AllowVersionDowngrade: false,
+      MaximumDeltasBeforeFallback: 10,
+    };
+
+    const um = new UpdateManager(options, locator);
+
+    expect(um.getAppId()).toBe("Test.Squirrel-App");
+    expect(um.getCurrentVersion()).toBe("1.0.0");
+  });
+});
+
+test("UpdateManager accepts an explicit VelopackFlowSource", async () => {
+  await tempd3(async (_tmpDir, packagesDir, rootDir) => {
+    const locator: VelopackLocatorConfig = {
+      ManifestPath: "../../test/fixtures/Test.Squirrel-App.nuspec",
+      PackagesDir: packagesDir,
+      RootAppDir: rootDir,
+      UpdateExePath: updateExe(),
+      CurrentBinaryDir: path.join(rootDir, "current"),
+      IsPortable: true,
+    };
+
+    const options: UpdateOptions = {
+      AllowVersionDowngrade: false,
+      MaximumDeltasBeforeFallback: 10,
+    };
+
+    const um = new UpdateManager(new VelopackFlowSource(), options, locator);
+
+    expect(um.getAppId()).toBe("Test.Squirrel-App");
+    expect(um.getCurrentVersion()).toBe("1.0.0");
   });
 });

--- a/src/lib-nodejs/velopack_nodeffi/src/lib.rs
+++ b/src/lib-nodejs/velopack_nodeffi/src/lib.rs
@@ -54,6 +54,10 @@ enum SourceDescriptor {
         #[serde(default)]
         prerelease: bool,
     },
+    Flow {
+        #[serde(rename = "baseUri")]
+        base_uri: Option<String>,
+    },
 }
 
 impl SourceDescriptor {
@@ -80,6 +84,7 @@ impl SourceDescriptor {
                 access_token,
                 prerelease,
             } => Box::new(GiteaSource::new(&repo_url, access_token, prerelease)),
+            SourceDescriptor::Flow { base_uri } => Box::new(VelopackFlowSource::new(base_uri.as_deref())),
         }
     }
 }
@@ -116,7 +121,6 @@ fn args_array_to_vec_string(cx: &mut FunctionContext, arg: Handle<JsArray>) -> N
 }
 
 fn js_new_update_manager(mut cx: FunctionContext) -> JsResult<BoxedUpdateManager> {
-    let arg_source = cx.argument::<JsString>(0)?.value(&mut cx);
     let arg_options = cx.argument::<JsString>(1)?.value(&mut cx);
 
     let mut options: Option<UpdateOptions> = None;
@@ -127,13 +131,33 @@ fn js_new_update_manager(mut cx: FunctionContext) -> JsResult<BoxedUpdateManager
         options = Some(new_opt);
     }
 
-    // The TypeScript layer passes a JSON source descriptor. A plain URL/path string
-    // (eg. from an older library version) falls back to auto-detection.
-    let source = match serde_json::from_str::<SourceDescriptor>(&arg_source) {
-        Ok(descriptor) => descriptor.into_source(),
-        Err(_) => Box::new(AutoSource::new(&arg_source)),
+    // The source argument is optional (may be null/undefined/empty from JS).
+    let mut arg_source: Option<String> = None;
+    if let Some(js_value) = cx.argument_opt(0) {
+        if js_value.is_a::<JsString, _>(&mut cx) {
+            if let Ok(js_string) = js_value.downcast::<JsString, _>(&mut cx) {
+                let value = js_string.value(&mut cx);
+                if !value.is_empty() {
+                    arg_source = Some(value);
+                }
+            }
+        }
+    }
+
+    let manager = match arg_source {
+        Some(arg_source) => {
+            // The TypeScript layer passes a JSON source descriptor. A plain URL/path string
+            // (eg. from an older library version) falls back to auto-detection.
+            let source = match serde_json::from_str::<SourceDescriptor>(&arg_source) {
+                Ok(descriptor) => descriptor.into_source(),
+                Err(_) => Box::new(AutoSource::new(&arg_source)),
+            };
+            UpdateManager::new_boxed(source, options, locator).or_else(|e| cx.throw_error(e.to_string()))?
+        }
+        // No source provided: retrieve updates from the hosted Velopack Flow service.
+        None => UpdateManager::new_flow(options, locator).or_else(|e| cx.throw_error(e.to_string()))?,
     };
-    let manager = UpdateManager::new_boxed(source, options, locator).or_else(|e| cx.throw_error(e.to_string()))?;
+
     let wrapper = UpdateManagerWrapper { manager };
     Ok(cx.boxed(RefCell::new(wrapper)))
 }

--- a/src/lib-python/src/lib.rs
+++ b/src/lib-python/src/lib.rs
@@ -11,7 +11,7 @@ mod manager;
 use manager::UpdateManagerWrapper;
 
 mod sources;
-use sources::{PyGiteaSource, PyGithubSource, PyGitlabSource, PyHttpSource};
+use sources::{PyGiteaSource, PyGithubSource, PyGitlabSource, PyHttpSource, PyVelopackFlowSource};
 
 use ::velopack::VelopackAsset;
 
@@ -53,6 +53,7 @@ fn velopack(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyGitlabSource>()?;
     m.add_class::<PyGiteaSource>()?;
     m.add_class::<PyHttpSource>()?;
+    m.add_class::<PyVelopackFlowSource>()?;
 
     // concrete classes
     m.add_class::<VelopackAppWrapper>()?;

--- a/src/lib-python/src/manager.rs
+++ b/src/lib-python/src/manager.rs
@@ -16,11 +16,18 @@ pub struct UpdateManagerWrapper {
 #[cfg_attr(feature = "stub-gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl UpdateManagerWrapper {
+    /// Create a new UpdateManager.
+    /// - `source`: Where to fetch updates from. Accepts an explicit source class or a URL/path
+    ///   string (auto-detected). If omitted, the hosted Velopack Flow service is used.
+    /// - `options`: Optional settings to customise the update behaviour.
+    /// - `locator`: Optional locator overriding how the current app's paths are discovered.
     #[new]
-    #[pyo3(signature = (source, options = None, locator = None))]
-    pub fn new(source: PySourceArg, options: Option<PyUpdateOptions>, locator: Option<PyVelopackLocatorConfig>) -> Result<Self> {
-        let source = source.into_source();
-        let inner = VelopackUpdateManagerRust::new_boxed(source, options.map(Into::into), locator.map(Into::into))?;
+    #[pyo3(signature = (source = None, options = None, locator = None))]
+    pub fn new(source: Option<PySourceArg>, options: Option<PyUpdateOptions>, locator: Option<PyVelopackLocatorConfig>) -> Result<Self> {
+        let inner = match source {
+            Some(source) => VelopackUpdateManagerRust::new_boxed(source.into_source(), options.map(Into::into), locator.map(Into::into))?,
+            None => VelopackUpdateManagerRust::new_flow(options.map(Into::into), locator.map(Into::into))?,
+        };
         Ok(UpdateManagerWrapper { inner })
     }
 

--- a/src/lib-python/src/sources.rs
+++ b/src/lib-python/src/sources.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use velopack::sources::{AutoSource, GiteaSource, GithubSource, GitlabSource, HttpSource, UpdateSource};
+use velopack::sources::{AutoSource, GiteaSource, GithubSource, GitlabSource, HttpSource, UpdateSource, VelopackFlowSource};
 
 use crate::types::PyHttpOptions;
 
@@ -108,6 +108,26 @@ impl PyHttpSource {
     }
 }
 
+/// Retrieves updates from the hosted Velopack Flow service (https://velopack.io).
+#[cfg_attr(feature = "stub-gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[pyclass(name = "VelopackFlowSource", from_py_object)]
+#[derive(Clone)]
+pub struct PyVelopackFlowSource {
+    pub base_uri: Option<String>,
+}
+
+#[cfg_attr(feature = "stub-gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
+#[pymethods]
+impl PyVelopackFlowSource {
+    /// Create a new VelopackFlowSource.
+    /// - `base_uri`: Optional base URL, defaults to the hosted service ("https://api.velopack.io/").
+    #[new]
+    #[pyo3(signature = (base_uri = None))]
+    pub fn new(base_uri: Option<String>) -> Self {
+        PyVelopackFlowSource { base_uri }
+    }
+}
+
 /// A union type accepted by UpdateManager that can be either a URL/path string
 /// (auto-detected) or one of the explicit source classes.
 #[derive(FromPyObject)]
@@ -116,6 +136,7 @@ pub enum PySourceArg {
     Gitlab(PyGitlabSource),
     Gitea(PyGiteaSource),
     Http(PyHttpSource),
+    Flow(PyVelopackFlowSource),
     Auto(String),
 }
 
@@ -129,6 +150,7 @@ impl PySourceArg {
                 Some(options) => Box::new(HttpSource::new_with_options(&s.url, options.into())),
                 None => Box::new(HttpSource::new(&s.url)),
             },
+            PySourceArg::Flow(s) => Box::new(VelopackFlowSource::new(s.base_uri.as_deref())),
             PySourceArg::Auto(s) => Box::new(AutoSource::new(&s)),
         }
     }
@@ -136,4 +158,4 @@ impl PySourceArg {
 
 // FromPyObject unions aren't pyclasses, so stub-gen can't derive their Python type. Describe it explicitly.
 #[cfg(feature = "stub-gen")]
-pyo3_stub_gen::impl_stub_type!(PySourceArg = PyGithubSource | PyGitlabSource | PyGiteaSource | PyHttpSource | String);
+pyo3_stub_gen::impl_stub_type!(PySourceArg = PyGithubSource | PyGitlabSource | PyGiteaSource | PyHttpSource | PyVelopackFlowSource | String);

--- a/src/lib-python/test/test_flow_source.py
+++ b/src/lib-python/test/test_flow_source.py
@@ -1,0 +1,67 @@
+"""Tests for the Velopack Flow update source and the Flow-by-default UpdateManager.
+
+Mirrors the Rust `manager_flow.rs` test: builds a locator pointing at the
+`Test.Squirrel-App.nuspec` fixture and verifies the manager can be constructed
+both with no source (defaulting to Velopack Flow) and with an explicit
+`VelopackFlowSource`, reading identity from the manifest without any network.
+"""
+
+import tempfile
+from pathlib import Path
+
+import velopack
+
+
+def _fixture_manifest() -> Path:
+    # test/ -> lib-python -> src -> repo root; fixtures live under repo-root test/fixtures.
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "test" / "fixtures" / "Test.Squirrel-App.nuspec"
+
+
+def _make_locator(root: Path) -> velopack.VelopackLocatorConfig:
+    packages_dir = root / "packages"
+    current_binary_dir = root / "current"
+    update_exe_path = root / "Update.exe"
+    packages_dir.mkdir(parents=True, exist_ok=True)
+    current_binary_dir.mkdir(parents=True, exist_ok=True)
+    update_exe_path.write_bytes(b"")
+    return velopack.VelopackLocatorConfig(
+        RootAppDir=root,
+        UpdateExePath=update_exe_path,
+        PackagesDir=packages_dir,
+        ManifestPath=_fixture_manifest(),
+        CurrentBinaryDir=current_binary_dir,
+        IsPortable=True,
+    )
+
+
+def test_update_manager_defaults_to_flow():
+    with tempfile.TemporaryDirectory() as tmp:
+        locator = _make_locator(Path(tmp) / "root")
+        # No source argument -> the hosted Velopack Flow service is assumed.
+        um = velopack.UpdateManager(locator=locator)
+        assert um.get_app_id() == "Test.Squirrel-App"
+        assert um.get_current_version() == "1.0.0"
+
+
+def test_update_manager_with_explicit_flow_source():
+    with tempfile.TemporaryDirectory() as tmp:
+        locator = _make_locator(Path(tmp) / "root")
+        um = velopack.UpdateManager(velopack.VelopackFlowSource(), locator=locator)
+        assert um.get_app_id() == "Test.Squirrel-App"
+        assert um.get_current_version() == "1.0.0"
+
+
+def test_flow_source_accepts_custom_base_uri():
+    with tempfile.TemporaryDirectory() as tmp:
+        locator = _make_locator(Path(tmp) / "root")
+        source = velopack.VelopackFlowSource("http://localhost:65531/")
+        um = velopack.UpdateManager(source, locator=locator)
+        assert um.get_app_id() == "Test.Squirrel-App"
+
+
+if __name__ == "__main__":
+    test_update_manager_defaults_to_flow()
+    test_update_manager_with_explicit_flow_source()
+    test_flow_source_accepts_custom_base_uri()
+    print("All Flow source tests passed.")

--- a/src/lib-python/velopack.pyi
+++ b/src/lib-python/velopack.pyi
@@ -17,6 +17,7 @@ __all__ = [
     "UpdateManager",
     "UpdateOptions",
     "VelopackAsset",
+    "VelopackFlowSource",
     "VelopackLocatorConfig",
 ]
 
@@ -225,7 +226,14 @@ class UpdateInfo:
 
 @typing.final
 class UpdateManager:
-    def __new__(cls, source: GithubSource  |  GitlabSource  |  GiteaSource  |  HttpSource  |  builtins.str, options: typing.Optional[UpdateOptions] = None, locator: typing.Optional[VelopackLocatorConfig] = None) -> UpdateManager: ...
+    def __new__(cls, source: typing.Optional[GithubSource  |  GitlabSource  |  GiteaSource  |  HttpSource  |  VelopackFlowSource  |  builtins.str] = None, options: typing.Optional[UpdateOptions] = None, locator: typing.Optional[VelopackLocatorConfig] = None) -> UpdateManager:
+        r"""
+        Create a new UpdateManager.
+        - `source`: Where to fetch updates from. Accepts an explicit source class or a URL/path
+          string (auto-detected). If omitted, the hosted Velopack Flow service is used.
+        - `options`: Optional settings to customise the update behaviour.
+        - `locator`: Optional locator overriding how the current app's paths are discovered.
+        """
     def get_current_version(self) -> builtins.str: ...
     def get_app_id(self) -> builtins.str: ...
     def get_is_portable(self) -> builtins.bool: ...
@@ -390,6 +398,17 @@ class VelopackAsset:
         The release notes in HTML format, transformed from Markdown when packaging the release. This may be an empty string.
         """
     def __new__(cls, PackageId: builtins.str, Version: builtins.str, Type: builtins.str, FileName: builtins.str, SHA1: builtins.str, SHA256: builtins.str, Size: builtins.int, NotesMarkdown: builtins.str, NotesHtml: builtins.str) -> VelopackAsset: ...
+
+@typing.final
+class VelopackFlowSource:
+    r"""
+    Retrieves updates from the hosted Velopack Flow service (https://velopack.io).
+    """
+    def __new__(cls, base_uri: typing.Optional[builtins.str] = None) -> VelopackFlowSource:
+        r"""
+        Create a new VelopackFlowSource.
+        - `base_uri`: Optional base URL, defaults to the hosted service ("https://api.velopack.io/").
+        """
 
 @typing.final
 class VelopackLocatorConfig:

--- a/src/lib-rust/src/lib.rs
+++ b/src/lib-rust/src/lib.rs
@@ -48,7 +48,7 @@
 //!         um.download_updates(&updates, None).unwrap();
 //!
 //!         // download completed, let's restart and update
-//!         um.apply_updates_and_restart(&updates).unwrap();
+//!         um.apply_updates_and_restart(&*updates).unwrap();
 //!     }
 //! }
 //! ```

--- a/src/lib-rust/src/manager.rs
+++ b/src/lib-rust/src/manager.rs
@@ -499,12 +499,12 @@ impl UpdateManager {
             let delta_file = packages_dir.join(&delta.FileName);
             let partial_file = delta_file.with_extension("partial");
 
-            info!("Downloading delta package: '{}'", &delta.FileName);
+            info!("Downloading delta package: '{}'", delta.FileName);
             self.inner.source.download_release_entry(delta, &partial_file, None)?;
             self.verify_package_checksum(&partial_file, delta)?;
 
             fs::rename(&partial_file, &delta_file)?;
-            debug!("Successfully downloaded file: '{}'", &delta.FileName);
+            debug!("Successfully downloaded file: '{}'", delta.FileName);
             if let Some(progress) = &progress {
                 let _ = progress.send(((i as f64 / update.DeltasToTarget.len() as f64) * 70.0) as i16);
             }
@@ -629,7 +629,7 @@ impl UpdateManager {
         let pkg_path = self.inner.locator.get_packages_dir().join(&to_apply.FileName);
 
         if !pkg_path.exists() {
-            error!("Package does not exist on disk: '{:?}'", &pkg_path);
+            error!("Package does not exist on disk: '{:?}'", pkg_path);
             return Err(Error::FileNotFound(pkg_path));
         }
 

--- a/src/lib-rust/src/manager.rs
+++ b/src/lib-rust/src/manager.rs
@@ -10,7 +10,7 @@ use crate::{
     constants,
     locator::{self, LocationContext, VelopackLocator, VelopackLocatorConfig},
     misc,
-    sources::UpdateSource,
+    sources::{UpdateSource, VelopackFlowSource},
     Error,
 };
 
@@ -164,6 +164,21 @@ pub enum UpdateCheck {
 }
 
 impl UpdateManager {
+    /// Create a new UpdateManager instance using a `VelopackFlowSource`, which retrieves
+    /// updates from the hosted Velopack Flow service (https://velopack.io).
+    /// This is a convenience function which is equivalent to creating a `VelopackFlowSource`
+    /// and passing it to `UpdateManager::new`.
+    /// This will return an error if the application is not yet installed.
+    /// ## Example:
+    /// ```rust
+    /// use velopack::*;
+    ///
+    /// let um = UpdateManager::new_flow(None, None);
+    /// ```
+    pub fn new_flow(options: Option<UpdateOptions>, locator: Option<VelopackLocatorConfig>) -> Result<UpdateManager, Error> {
+        UpdateManager::new(VelopackFlowSource::new(None), options, locator)
+    }
+
     /// Create a new UpdateManager instance using the specified UpdateSource.
     /// This will return an error if the application is not yet installed.
     /// ## Example:

--- a/src/lib-rust/tests/manager_flow.rs
+++ b/src/lib-rust/tests/manager_flow.rs
@@ -1,0 +1,39 @@
+use std::{fs, path::PathBuf};
+
+use velopack::{locator::VelopackLocatorConfig, UpdateManager};
+
+fn test_manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("test")
+        .join("fixtures")
+        .join("Test.Squirrel-App.nuspec")
+}
+
+#[test]
+fn new_flow_creates_manager_without_explicit_source() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_dir = temp_dir.path().join("root");
+    let packages_dir = root_dir.join("packages");
+    let current_binary_dir = root_dir.join("current");
+    let update_exe_path = root_dir.join("Update.exe");
+
+    fs::create_dir_all(&packages_dir).unwrap();
+    fs::create_dir_all(&current_binary_dir).unwrap();
+    fs::write(&update_exe_path, []).unwrap();
+
+    let locator = VelopackLocatorConfig {
+        RootAppDir: root_dir,
+        UpdateExePath: update_exe_path,
+        PackagesDir: packages_dir,
+        ManifestPath: test_manifest_path(),
+        CurrentBinaryDir: current_binary_dir,
+        IsPortable: true,
+    };
+
+    let manager = UpdateManager::new_flow(None, Some(locator)).unwrap();
+
+    assert_eq!(manager.get_app_id(), "Test.Squirrel-App");
+    assert_eq!(manager.get_current_version_as_string(), "1.0.0");
+}

--- a/src/vpk/Velopack.Vpk/Program.cs
+++ b/src/vpk/Velopack.Vpk/Program.cs
@@ -169,11 +169,11 @@ public class Program
         deltaCommand.AddCommand<DeltaPatchCommand, DeltaPatchCommandRunner, DeltaPatchOptions>(provider);
         rootCommand.Add(deltaCommand);
 
-        HideCommand(rootCommand.AddCommand<LoginCommand, LoginCommandRunner, LoginOptions>(provider));
-        HideCommand(rootCommand.AddCommand<LogoutCommand, LogoutCommandRunner, LogoutOptions>(provider));
-        HideCommand(rootCommand.AddCommand<PublishCommand, PublishCommandRunner, PublishOptions>(provider));
+        rootCommand.AddCommand<LoginCommand, LoginCommandRunner, LoginOptions>(provider);
+        rootCommand.AddCommand<LogoutCommand, LogoutCommandRunner, LogoutOptions>(provider);
+        rootCommand.AddCommand<PublishCommand, PublishCommandRunner, PublishOptions>(provider);
 
-        var flowCommand = new Command("flow", "Commands for interacting with Velopack Flow.") { Hidden = true };
+        var flowCommand = new Command("flow", "Commands for interacting with Velopack Flow.");
         HideCommand(flowCommand.AddCommand<ApiCommand, ApiCommandRunner, ApiOptions>(provider));
         rootCommand.Add(flowCommand); 
 

--- a/test/Velopack.Packaging.Tests/MsiTests.cs
+++ b/test/Velopack.Packaging.Tests/MsiTests.cs
@@ -22,6 +22,18 @@ public class MsiTests
         _output = output;
     }
 
+    private static void WaitUntilInstallDirUnlocked(string installDir)
+    {
+        // After an apply, Update.exe / the restarted app / the coverage collector may still be
+        // exiting in the background. While any of them run from the install dir, the MSI cleanup
+        // action cannot remove the directory, so wait until every exe can be opened exclusively.
+        TestHelper.WaitUntil(() => {
+            foreach (var exe in Directory.EnumerateFiles(installDir, "*.exe", SearchOption.AllDirectories)) {
+                File.Open(exe, FileMode.Open, FileAccess.ReadWrite, FileShare.None).Dispose();
+            }
+        }, pollDelayMs: 1000);
+    }
+
     private static string RunMsiExec(string rawArgs, ILogger logger, int? exitCode = 0)
     {
         var outputFile = PathHelper.GetTestRootPath($"run.{WindowsTestHelper.RandomString(8)}.log");
@@ -531,6 +543,7 @@ public class MsiTests
 
             // uninstall using the same MSI that was used to install.
             // (msiexec /x requires the MSI's ProductCode to match a registered product.)
+            WaitUntilInstallDirUnlocked(installDir);
             logger.Info("TEST: Uninstalling MSI...");
             RunMsiExec($"/x \"{v1MsiPath}\" /qn", logger);
 

--- a/test/Velopack.Tests/UpdateManagerTests.cs
+++ b/test/Velopack.Tests/UpdateManagerTests.cs
@@ -102,6 +102,18 @@ public class UpdateManagerTests
     }
 
     [Fact]
+    public void ConstructsWithFlowSourceWhenNoSourceProvided()
+    {
+        using var logger = _output.BuildLoggerFor<UpdateManagerTests>();
+        using var _1 = TempUtil.GetTempDirectory(out var tempPath);
+        var locator = new TestVelopackLocator("MyCoolApp", "1.0.0", tempPath, logger.ToVelopackLogger());
+        var um = new UpdateManager(locator: locator);
+        Assert.Equal("MyCoolApp", um.AppId);
+        Assert.True(new SemanticVersion(1, 0, 0) == um.CurrentVersion);
+        Assert.True(um.IsInstalled);
+    }
+
+    [Fact]
     public async Task CanDownloadFilesAsUrl()
     {
         var fixture = PathHelper.GetFixture("AvaloniaCrossPlat-1.0.11-win-full.nupkg");


### PR DESCRIPTION
Closes #876 (reworked against the current codebase, without the `new_default` naming).

With the launch of Velopack Flow, the Flow update source is now a public, first-class source in every client library — it can be instantiated normally and passed to the existing `UpdateManager` constructors like any other source. In addition, since Flow works with no extra parameters, it is the assumed source when none is provided:

## Library changes

| Language | Explicit source | Convenience (no source → Flow) |
|---|---|---|
| C# | `VelopackFlowSource` (already public) | new `UpdateManager(options, locator)` overload |
| Rust | `sources::VelopackFlowSource` (already public) | `UpdateManager::new_flow(options, locator)` |
| C | `vpkc_new_source_velopack_flow` (already public) | `vpkc_new_update_manager_flow(options, locator, manager)` |
| C++ | `Velopack::VelopackFlowSource` (already public) | new source-less `UpdateManager(options, locator)` ctor |
| Node.js | **new** `VelopackFlowSource` class (+ `kind: "flow"` FFI descriptor) | new constructor overloads: `new UpdateManager()` / `new UpdateManager(options, locator)` |
| Python | **new** `VelopackFlowSource` class | `source` parameter is now optional (`UpdateManager()`) |

Languages with overloading (C#, C++, TypeScript) get constructor overloads; languages without (Rust, C) get `new_flow` / `_flow` convenience functions that create the Flow source and call the regular initialisation. Python uses an optional parameter. Python stubs (`velopack.pyi`) regenerated.

## CLI changes

`vpk login`, `vpk logout`, `vpk publish` and the `vpk flow` command group are no longer hidden. `vpk flow api` remains hidden as an internal diagnostic command.

## Tests

- Rust: new `manager_flow.rs` integration test; full suite passes (`cargo test -p velopack --features public-utils`, 114 unit + all integration + doc tests)
- C ABI: new `new_update_manager_flow_uses_flow_source` test (`cargo test -p velopack_libc`, 10/10); `Velopack.hpp` verified with MSVC syntax-only compile
- C#: new `ConstructsWithFlowSourceWhenNoSourceProvided` test; `Velopack.Tests` passes (the only local failures are the symlink-privilege tests that require Developer Mode); `Velopack.CommandLine.Tests` 116/116
- Node.js: two new tests (implicit + explicit Flow source); vitest 11/11
- Python: new `test_flow_source.py` (3/3 via `maturin develop`)

Also includes a one-character drive-by fix for the crate-level doc example in `lib-rust/src/lib.rs` which passed `&Box<UpdateInfo>` to `apply_updates_and_restart` and broke `cargo test --doc` on develop.