### PR TITLE
Fix swapped MSI banner/dialog images, rename to --msiTopBanner and --msiDialogBackground

### DIFF
--- a/src/bins/src/commands/apply_osx_impl.rs
+++ b/src/bins/src/commands/apply_osx_impl.rs
@@ -98,11 +98,11 @@ pub fn apply_package_impl(locator: &VelopackLocator, pkg: &PathBuf, _hook_mode: 
                     dialogs::ask_user_to_elevate(&manifest.title, &manifest.version.to_string())?;
                     let script = format!(
                         "do shell script \"mv -f '{}' '{}' && mv -f '{}' '{}' && rm -rf '{}'\" with administrator privileges",
-                        &root_path.to_string_lossy(),
-                        &tmp_path_old.to_string_lossy(),
-                        &tmp_path_new.to_string_lossy(),
-                        &root_path.to_string_lossy(),
-                        &tmp_path_old.to_string_lossy()
+                        root_path.to_string_lossy(),
+                        tmp_path_old.to_string_lossy(),
+                        tmp_path_new.to_string_lossy(),
+                        root_path.to_string_lossy(),
+                        tmp_path_old.to_string_lossy()
                     );
                     info!("Running elevated process via osascript: {}", script);
                     let output = Command::new("osascript").arg("-e").arg(&script).status()?;

--- a/src/vpk/Velopack.Build/PackTask.cs
+++ b/src/vpk/Velopack.Build/PackTask.cs
@@ -67,8 +67,8 @@ public class PackTask : MSBuildAsyncTask
 
     public InstallLocation InstLocation { get; set; } = InstallLocation.Either;
 
-    public string? MsiBanner { get; set; }
-    public string? MsiLogo { get; set; }
+    public string? MsiTopBanner { get; set; }
+    public string? MsiDialogBackground { get; set; }
 
     public string? SignAppIdentity { get; set; }
 

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptions.cs
@@ -36,8 +36,8 @@ public class WindowsPackOptions : WindowsReleasifyOptions, INugetPackCommand, IP
 
     public InstallLocation InstLocation { get; set; } = InstallLocation.Either;
 
-    public string MsiBanner { get; set; }
-    public string MsiLogo { get; set; }
+    public string MsiTopBanner { get; set; }
+    public string MsiDialogBackground { get; set; }
 
     public bool BuildMsi { get; set; }
 

--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptionsValidator.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackOptionsValidator.cs
@@ -16,8 +16,8 @@ public sealed class WindowsPackOptionsValidator : PackOptionsValidator<WindowsPa
         RuleFor(x => x.SignExclude).MustBeValidRegex();
         RuleFor(x => x.AzureTrustedSignFile).MustBeExistingFile();
         RuleFor(x => x.MsiVersionOverride).MustBeValidMsiVersion();
-        RuleFor(x => x.MsiBanner).MustHaveExtension(".bmp");
-        RuleFor(x => x.MsiLogo).MustHaveExtension(".bmp");
+        RuleFor(x => x.MsiTopBanner).MustHaveExtension(".bmp");
+        RuleFor(x => x.MsiDialogBackground).MustHaveExtension(".bmp");
         RuleFor(x => x.InstWelcome).MustBeExistingFile();
         RuleFor(x => x.InstReadme).MustBeExistingFile();
         RuleFor(x => x.InstLicense).MustBeExistingFile();

--- a/src/vpk/Velopack.Packaging.Windows/Msi/MsiBuilder.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/MsiBuilder.cs
@@ -172,8 +172,8 @@ public static class MsiBuilder
             StartMenuRootShortcut = shortcuts.HasFlag(ShortcutLocation.StartMenuRoot),
             StartupShortcut = shortcuts.HasFlag(ShortcutLocation.Startup),
             RustNativeModulePath = HelperFile.GetWixNativeModulePath(options.TargetRuntime),
-            SideBannerImagePath = options.MsiBanner,
-            TopBannerImagePath = options.MsiLogo,
+            BannerBmpPath = options.MsiTopBanner,
+            DialogBmpPath = options.MsiDialogBackground,
             RuntimeDependencies = runtimeDeps,
             ConclusionMessage = GetPlainTextMessage(options.InstConclusion),
             ReadmeRtfFilePath = GetRtfPath(options.InstReadme, "rendered_readme.rtf", portableDir.Parent),
@@ -192,8 +192,8 @@ public static class MsiBuilder
         var wixId = data.WixId;
         var wxsPath = Path.Combine(outputDir, wixId + ".wxs");
 
-        data.BannerBmpPath = data.HasTopBannerImage ? data.TopBannerImagePath : ExtractResource("banner.bmp", outputDir);
-        data.DialogBmpPath = data.HasSideBannerImage ? data.SideBannerImagePath : ExtractResource("dialog.bmp", outputDir);
+        if (!data.HasBannerBmp) data.BannerBmpPath = ExtractResource("banner.bmp", outputDir);
+        if (!data.HasDialogBmp) data.DialogBmpPath = ExtractResource("dialog.bmp", outputDir);
         data.ExclamIcoPath = ExtractResource("exclam.ico", outputDir);
         data.UpIcoPath = ExtractResource("up.ico", outputDir);
         data.NewIcoPath = ExtractResource("new.ico", outputDir);

--- a/src/vpk/Velopack.Packaging.Windows/Msi/MsiTemplateData.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/MsiTemplateData.cs
@@ -58,14 +58,19 @@ public class MsiTemplateData
     public bool HasReadme => !string.IsNullOrWhiteSpace(ReadmeRtfFilePath);
     public string ReadmeRtfFilePath;
 
-    public bool HasTopBannerImage => !string.IsNullOrWhiteSpace(TopBannerImagePath) && File.Exists(TopBannerImagePath);
-    public string TopBannerImagePath;
-
-    public bool HasSideBannerImage => !string.IsNullOrWhiteSpace(SideBannerImagePath) && File.Exists(SideBannerImagePath);
-    public string SideBannerImagePath;
-
+    /// <summary>
+    /// The narrow strip across the top of most MSI dialogs (WiX binary WixUI_Bmp_Banner, 493x58).
+    /// Set from --msiTopBanner; a default is substituted at compile time if unset or missing.
+    /// </summary>
     public string BannerBmpPath;
+    public bool HasBannerBmp => !string.IsNullOrWhiteSpace(BannerBmpPath) && File.Exists(BannerBmpPath);
+
+    /// <summary>
+    /// The full background of the MSI welcome/completion dialogs (WiX binary WixUI_Bmp_Dialog, 493x312).
+    /// Set from --msiDialogBackground; a default is substituted at compile time if unset or missing.
+    /// </summary>
     public string DialogBmpPath;
+    public bool HasDialogBmp => !string.IsNullOrWhiteSpace(DialogBmpPath) && File.Exists(DialogBmpPath);
     public string ExclamIcoPath;
     public string UpIcoPath;
     public string NewIcoPath;

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
@@ -35,8 +35,8 @@ public class WindowsPackCommand : PackCommand
 
     public InstallLocation InstLocation { get; private set; }
 
-    public string MsiBanner { get; private set; }
-    public string MsiLogo { get; private set; }
+    public string MsiTopBanner { get; private set; }
+    public string MsiDialogBackground { get; private set; }
 
 
     public bool BuildMsi { get; private set; }
@@ -126,12 +126,12 @@ public class WindowsPackCommand : PackCommand
                 .SetDescription("Set the installation location.")
                 .SetArgumentHelpName("LOCATION");
 
-            AddOption<FileInfo>(v => MsiBanner = v.ToFullNameOrNull(), ["--msiBanner"])
-                .SetDescription("Set the top banner bitmap image for the MSI UI dialogs. The resolution must be 493x58.")
+            AddOption<FileInfo>(v => MsiTopBanner = v.ToFullNameOrNull(), ["--msiTopBanner"])
+                .SetDescription("Set the top banner strip of the MSI dialogs (493x58 BMP).")
                 .SetArgumentHelpName("PATH");
 
-            AddOption<FileInfo>(v => MsiLogo = v.ToFullNameOrNull(), ["--msiLogo"])
-                .SetDescription("Set the background logo bitmap image for the MSI UI dialogs. The resolution must be 493x312.")
+            AddOption<FileInfo>(v => MsiDialogBackground = v.ToFullNameOrNull(), ["--msiDialogBackground"])
+                .SetDescription("Set the MSI welcome/finish dialog background (493x312 BMP).")
                 .SetArgumentHelpName("PATH");
         }
     }

--- a/test/Velopack.Packaging.Tests/MsiTests.cs
+++ b/test/Velopack.Packaging.Tests/MsiTests.cs
@@ -286,6 +286,70 @@ public class MsiTests
     }
 
     [Fact]
+    public async Task TestPackGeneratesMsiWithCorrectBannerAndDialogImages()
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+
+        using var logger = _output.BuildLoggerFor<MsiTests>();
+
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+        using var _3 = TempUtil.GetTempDirectory(out var tmpAssets);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+        PathHelper.CopyRustAssetTo(Path.ChangeExtension(exe, ".pdb"), tmpOutput);
+
+        // WiX embeds the files verbatim without decoding them, so marker bytes are enough
+        // to tell which file ended up on which WiX binary
+        var bannerFile = Path.Combine(tmpAssets, "custom_banner.bmp");
+        var dialogFile = Path.Combine(tmpAssets, "custom_dialog.bmp");
+        var bannerBytes = "TOP_BANNER_493x58_MARKER"u8.ToArray();
+        var dialogBytes = "DIALOG_BACKGROUND_493x312_MARKER"u8.ToArray();
+        File.WriteAllBytes(bannerFile, bannerBytes);
+        File.WriteAllBytes(dialogFile, dialogBytes);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = "1.2.3",
+            TargetRuntime = RID.Parse("win-x64"),
+            PackDirectory = tmpOutput,
+            BuildMsi = true,
+            MsiTopBanner = bannerFile,
+            MsiDialogBackground = dialogFile,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        await runner.Run(options);
+
+        string msiPath = Path.Combine(tmpReleaseDir, $"{id}-win.msi");
+        Assert.True(File.Exists(msiPath));
+
+        using Database db = new Database(msiPath);
+
+        // --msiTopBanner -> the 493x58 top strip, --msiDialogBackground -> the 493x312
+        // welcome/finish dialog background. these were applied swapped before (#1005)
+        Assert.Equal(bannerBytes, ReadMsiBinaryData(db, "WixUI_Bmp_Banner"));
+        Assert.Equal(dialogBytes, ReadMsiBinaryData(db, "WixUI_Bmp_Dialog"));
+    }
+
+    private static byte[] ReadMsiBinaryData(Database db, string name)
+    {
+        using var view = db.OpenView($"SELECT `Data` FROM `Binary` WHERE `Name` = '{name}'");
+        view.Execute();
+        using var record = view.Fetch();
+        Assert.NotNull(record);
+        using var stream = record.GetStream(1);
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    [Fact]
     public async Task TestPackGeneratesMsiWithSpecifiedVersion()
     {
         Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");


### PR DESCRIPTION
Closes #1005

Renames these cli arguments:
- `--msiBanner` → `--msiTopBanner`
- `--msiLogo` → `--msiDialogBackground`