### PR TITLE
Fix MSI uninstall cleanup; preserve user data on MSI upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4623,6 +4623,7 @@ dependencies = [
  "velopack_bins",
  "velopack_l18n",
  "windows",
+ "winreg",
 ]
 
 [[package]]

--- a/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
@@ -194,9 +194,21 @@
         <CustomAction Id="RustSetLocaleStrings" BinaryRef="RustDll" DllEntry="RustSetLocaleStrings" Execute="immediate" Return="check"/>
         <CustomAction Id="RustValidatePath" BinaryRef="RustDll" DllEntry="ValidatePath" Execute="immediate" Return="check"/>
         <CustomAction Id="RustEarlyBootstrap" BinaryRef="RustDll" DllEntry="EarlyBootstrap" Execute="immediate" Return="check"/>
-        <CustomAction Id="SetRustCleanupData" Property="RustCleanup" Value="[INSTALLFOLDER]&quot;[RustAppId]&quot;[TempFolder]" Execute="immediate"
-                      Return="check"/>
+        <!-- On full uninstall RustCleanup removes everything left in the install dir; during a
+             major upgrade ([UPGRADINGPRODUCTCODE] set in the old product being removed) it only
+             purges the `current` payload dir so user files outside it survive the upgrade.
+             UserRustCleanup runs impersonated on full uninstall only, to clean per-user state
+             (shortcuts, %LocalAppData% fallback dir, temp) that the non-impersonated action
+             cannot resolve when it runs as SYSTEM on per-machine installs. -->
+        <CustomAction Id="SetRustCleanupData" Property="RustCleanup"
+                      Value="[INSTALLFOLDER]&quot;[RustAppId]&quot;[TempFolder]&quot;[LocalAppDataFolder]&quot;[UPGRADINGPRODUCTCODE]"
+                      Execute="immediate" Return="check"/>
         <CustomAction Id="RustCleanup" BinaryRef="RustDll" DllEntry="CleanupDeferred" Execute="deferred" Impersonate="no" Return="ignore"/>
+        <CustomAction Id="SetUserRustCleanupData" Property="UserRustCleanup"
+                      Value="[INSTALLFOLDER]&quot;[RustAppId]&quot;[TempFolder]&quot;[LocalAppDataFolder]"
+                      Execute="immediate" Return="check"/>
+        <CustomAction Id="UserRustCleanup" BinaryRef="RustDll" DllEntry="UserCleanupDeferred" Execute="deferred" Impersonate="yes"
+                      Return="ignore"/>
         <CustomAction Id="RustLaunchApplication" BinaryRef="RustDll" DllEntry="LaunchApplication" Impersonate="yes" Execute="immediate"
                       Return="ignore"/>
 
@@ -229,10 +241,19 @@
             <Custom Action="SetInstallHookData" Before="InstallHookDeferred" Condition="NOT REMOVE"/>
             <!-- InstallHookDeferred runs after PatchChannelDeferred so the app hook sees the corrected channel -->
             <Custom Action="InstallHookDeferred" After="PatchChannelDeferred" Condition="NOT REMOVE"/>
-            <Custom Action="SetUninstallHookData" Before="UninstallHookDeferred" Condition="(REMOVE=&quot;ALL&quot;)"/>
-            <Custom Action="UninstallHookDeferred" Before="RemoveFiles" Condition="(REMOVE=&quot;ALL&quot;)"/>
+            <!-- The app uninstall hook and per-user cleanup only run on a real uninstall, not when
+                 the old product is removed as part of a major upgrade. RustCleanup runs in both
+                 cases; it decides what to remove based on [UPGRADINGPRODUCTCODE]. -->
+            <Custom Action="SetUninstallHookData" Before="UninstallHookDeferred"
+                    Condition="(REMOVE=&quot;ALL&quot;) AND NOT UPGRADINGPRODUCTCODE"/>
+            <Custom Action="UninstallHookDeferred" Before="RemoveFiles"
+                    Condition="(REMOVE=&quot;ALL&quot;) AND NOT UPGRADINGPRODUCTCODE"/>
             <Custom Action="SetRustCleanupData" Before="RustCleanup" Condition="(REMOVE=&quot;ALL&quot;)"/>
-            <Custom Action="RustCleanup" Before="RemoveFolders" Condition="(REMOVE=&quot;ALL&quot;)"/>
+            <Custom Action="RustCleanup" After="RemoveFiles" Condition="(REMOVE=&quot;ALL&quot;)"/>
+            <Custom Action="SetUserRustCleanupData" Before="UserRustCleanup"
+                    Condition="(REMOVE=&quot;ALL&quot;) AND NOT UPGRADINGPRODUCTCODE"/>
+            <Custom Action="UserRustCleanup" After="RustCleanup"
+                    Condition="(REMOVE=&quot;ALL&quot;) AND NOT UPGRADINGPRODUCTCODE"/>
         </InstallExecuteSequence>
 
         <UI>

--- a/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
+++ b/src/vpk/Velopack.Packaging.Windows/Msi/Templates/MsiTemplate.hbs
@@ -136,10 +136,12 @@
 
         <!-- Optional install-dir override for sysadmins, e.g. msiexec /i app.msi VELOPACK_INSTALLDIR="D:\App".
              When set, the forced default path (LocalAppData/ProgramFiles) is skipped in both UI and silent
-             installs. Secure so it survives the UI -> execute sequence handoff for elevated per-machine installs. -->
+             installs. Secure so it survives the UI -> execute sequence handoff for elevated per-machine installs.
+             Only applied on first install: on maintenance/uninstall INSTALLFOLDER must resolve from the
+             registered component paths, so the property cannot redirect what the elevated cleanup deletes. -->
         <Property Id="VELOPACK_INSTALLDIR" Secure="yes"/>
         <SetProperty Id="INSTALLFOLDER" Value="[VELOPACK_INSTALLDIR]" Before="CostFinalize" Sequence="execute"
-                     Condition="VELOPACK_INSTALLDIR"/>
+                     Condition="VELOPACK_INSTALLDIR AND NOT Installed"/>
 
         <!-- Quiet/passive/reduced installs (UILevel < 5) never run the UI publishes that set the
              default INSTALLFOLDER, which would otherwise resolve to {ROOTDRIVE}\{AppTitle}. Apply
@@ -181,7 +183,9 @@
         <Binary Id="WixUI_Bmp_New" SourceFile="{{NewIcoPath}}"/>
 
         <!-- MSI properties for app metadata (used by Rust custom actions) -->
-        <Property Id="RustAppId" Value="{{AppTitle}}"/>
+        <!-- Must be the pack ID (not the title): cleanup uses it to locate the %LocalAppData%
+             fallback dir, the velopack temp dir and the MSI:{AppId} ARP key -->
+        <Property Id="RustAppId" Value="{{AppId}}"/>
         <Property Id="RustAppTitle" Value="{{AppTitle}}"/>
         <Property Id="RustAppVersion" Value="{{AppVersion}}"/>
         {{#if HasRuntimeDependencies}}

--- a/src/wix-dll/Cargo.toml
+++ b/src/wix-dll/Cargo.toml
@@ -24,6 +24,7 @@ velopack.workspace = true
 velopack_bins.workspace = true
 velopack_l18n.workspace = true
 remove_dir_all.workspace = true
+winreg.workspace = true
 windows = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/src/wix-dll/src/channel_tag.rs
+++ b/src/wix-dll/src/channel_tag.rs
@@ -139,7 +139,10 @@ mod tests {
         let result = apply_msi_channel_override(&msi, &install).unwrap();
         assert_eq!(result, Some("staging".to_string()));
         let patched = fs::read_to_string(&manifest).unwrap();
-        assert_eq!(patched, SQ_VERSION_FIXTURE.replace("<channel>win</channel>", "<channel>staging</channel>"));
+        assert_eq!(
+            patched,
+            SQ_VERSION_FIXTURE.replace("<channel>win</channel>", "<channel>staging</channel>")
+        );
     }
 
     #[test]

--- a/src/wix-dll/src/lib.rs
+++ b/src/wix-dll/src/lib.rs
@@ -78,50 +78,123 @@ pub extern "system" fn EarlyBootstrap(h_install: MSIHANDLE) -> c_uint {
     }
 }
 
+/// Parses the CustomActionData marshaled by SetRustCleanupData / SetUserRustCleanupData:
+/// `[INSTALLFOLDER]"[RustAppId]"[TempFolder]"[LocalAppDataFolder]"[UPGRADINGPRODUCTCODE]`
+/// (the last field is only present for RustCleanup, and is empty unless the product is being
+/// removed as part of a major upgrade).
+struct CleanupData {
+    install_dir: String,
+    app_id: String,
+    temp_dir: String,
+    local_app_data: String,
+    is_upgrading: bool,
+}
+
+fn parse_cleanup_data(custom_data: &str) -> CleanupData {
+    let mut parts = custom_data.split('"');
+    CleanupData {
+        install_dir: parts.next().unwrap_or("").to_string(),
+        app_id: parts.next().unwrap_or("").to_string(),
+        temp_dir: parts.next().unwrap_or("").to_string(),
+        local_app_data: parts.next().unwrap_or("").to_string(),
+        is_upgrading: parts.next().map(|s| !s.is_empty()).unwrap_or(false),
+    }
+}
+
+fn remove_dir_logged(fn_name: &str, dir: &Path) {
+    if let Err(e) = remove_dir_all::remove_dir_all(dir) {
+        show_debug_message(fn_name, format!("Failed to remove directory: {:?} {}", dir, e));
+    }
+}
+
+fn remove_msi_arp_registry_keys(fn_name: &str, app_id: &str) {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+    const UNINSTALL_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+    let subkey = format!("MSI:{}", app_id);
+    for root in [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE] {
+        if let Ok(uninstall) = RegKey::predef(root).open_subkey(UNINSTALL_KEY) {
+            if let Err(e) = uninstall.delete_subkey_all(&subkey) {
+                show_debug_message(fn_name, format!("Did not remove uninstall registry key {:?}: {}", subkey, e));
+            }
+        }
+    }
+}
+
+/// Deferred, non-impersonated (elevated on per-machine installs). On a full uninstall this removes
+/// everything left in the install dir (files from in-app updates, logs, user data — mirroring the
+/// Setup.exe/Update.exe uninstall behavior) plus any leftover ARP registry key. During a major
+/// upgrade it only purges the `current` payload dir so the incoming MSI lays down a clean payload
+/// while files outside `current` (user data, packages) survive.
 #[no_mangle]
 pub extern "system" fn CleanupDeferred(h_install: MSIHANDLE) -> c_uint {
     let custom_data = msi_get_property(h_install, "CustomActionData");
     show_debug_message("CleanupDeferred", format!("CustomActionData={:?}", custom_data));
 
     if let Some(custom_data) = custom_data {
-        // custom data will be a list delimited by " (0x22)
-        let mut custom_data = custom_data.split('"');
-        let install_dir = custom_data.next();
-        let app_id = custom_data.next();
-        let temp_dir = custom_data.next();
-
-        show_debug_message(
-            "CleanupDeferred",
-            format!("install_dir={:?}, app_id={:?}, temp_dir={:?}", install_dir, app_id, temp_dir),
-        );
-
-        if let Some(install_dir) = install_dir {
-            if let Err(e) = remove_dir_all::remove_dir_all(install_dir) {
-                show_debug_message("CleanupDeferred", format!("Failed to remove install directory: {:?} {}", install_dir, e));
-            }
+        let data = parse_cleanup_data(&custom_data);
+        if data.install_dir.is_empty() {
+            show_debug_message("CleanupDeferred", "Missing install_dir, skipping".to_string());
+            return ERROR_SUCCESS.0;
         }
 
-        if let Some(app_id) = app_id {
-            if let Ok(appdata) = std::env::var("LOCALAPPDATA") {
-                let velopack_app_dir = PathBuf::from(appdata).join(app_id);
-                if let Err(e) = remove_dir_all::remove_dir_all(&velopack_app_dir) {
-                    show_debug_message(
-                        "CleanupDeferred",
-                        format!("Failed to remove local app data directory: {:?} {}", velopack_app_dir, e),
-                    );
-                }
-            }
+        let install_dir = Path::new(&data.install_dir);
+        if data.is_upgrading {
+            show_debug_message("CleanupDeferred", "Major upgrade in progress, only purging 'current' dir".to_string());
+            remove_dir_logged("CleanupDeferred", &install_dir.join("current"));
+            return ERROR_SUCCESS.0;
+        }
 
-            if let Some(temp_dir) = temp_dir {
-                let temp_dir = PathBuf::from(temp_dir);
-                let temp_dir = temp_dir.join(format!("velopack_{}", app_id));
-                if let Err(e) = remove_dir_all::remove_dir_all(&temp_dir) {
-                    show_debug_message("CleanupDeferred", format!("Failed to remove temp directory: {:?} {}", temp_dir, e));
-                }
-            }
+        // the app could still be running from the install dir, which would prevent deletion
+        if let Err(e) = velopack_bins::shared::force_stop_package(install_dir) {
+            show_debug_message("CleanupDeferred", format!("Failed to stop running processes: {}", e));
+        }
+
+        remove_dir_logged("CleanupDeferred", install_dir);
+
+        if !data.app_id.is_empty() {
+            // remove any ARP entry left behind (e.g. values written by Update.exe, or an orphaned
+            // entry from a previous side-by-side install of the same app)
+            remove_msi_arp_registry_keys("CleanupDeferred", &data.app_id);
         }
 
         show_debug_message("CleanupDeferred", "Done!".to_string());
+    }
+
+    ERROR_SUCCESS.0
+}
+
+/// Deferred, impersonated as the installing user. Runs on full uninstall only, and cleans up the
+/// per-user state which CleanupDeferred cannot reliably reach when it runs as SYSTEM on
+/// per-machine installs: shortcuts pointing into the install dir, the `%LocalAppData%\{AppId}`
+/// fallback dir (packages + Update.exe copied there when the install dir is not writable), the
+/// velopack temp dir, and the HKCU ARP key.
+#[no_mangle]
+pub extern "system" fn UserCleanupDeferred(h_install: MSIHANDLE) -> c_uint {
+    let custom_data = msi_get_property(h_install, "CustomActionData");
+    show_debug_message("UserCleanupDeferred", format!("CustomActionData={:?}", custom_data));
+
+    if let Some(custom_data) = custom_data {
+        let data = parse_cleanup_data(&custom_data);
+
+        if !data.install_dir.is_empty() {
+            velopack_bins::windows::remove_all_shortcuts_for_root_dir(&data.install_dir);
+        }
+
+        if !data.app_id.is_empty() {
+            if !data.local_app_data.is_empty() {
+                remove_dir_logged("UserCleanupDeferred", &PathBuf::from(&data.local_app_data).join(&data.app_id));
+            }
+            if !data.temp_dir.is_empty() {
+                remove_dir_logged(
+                    "UserCleanupDeferred",
+                    &PathBuf::from(&data.temp_dir).join(format!("velopack_{}", data.app_id)),
+                );
+            }
+            remove_msi_arp_registry_keys("UserCleanupDeferred", &data.app_id);
+        }
+
+        show_debug_message("UserCleanupDeferred", "Done!".to_string());
     }
 
     ERROR_SUCCESS.0

--- a/src/wix-dll/src/lib.rs
+++ b/src/wix-dll/src/lib.rs
@@ -92,12 +92,22 @@ struct CleanupData {
 
 fn parse_cleanup_data(custom_data: &str) -> CleanupData {
     let mut parts = custom_data.split('"');
+    let install_dir = parts.next().unwrap_or("").to_string();
+    let mut app_id = parts.next().unwrap_or("").to_string();
+    let temp_dir = parts.next().unwrap_or("").to_string();
+    let local_app_data = parts.next().unwrap_or("").to_string();
+    let is_upgrading = parts.next().map(|s| !s.is_empty()).unwrap_or(false);
+    // app_id is joined onto profile paths and deleted recursively, so it must be a plain
+    // single path component
+    if app_id == "." || app_id == ".." || app_id.contains(['/', '\\', ':']) {
+        app_id = String::new();
+    }
     CleanupData {
-        install_dir: parts.next().unwrap_or("").to_string(),
-        app_id: parts.next().unwrap_or("").to_string(),
-        temp_dir: parts.next().unwrap_or("").to_string(),
-        local_app_data: parts.next().unwrap_or("").to_string(),
-        is_upgrading: parts.next().map(|s| !s.is_empty()).unwrap_or(false),
+        install_dir,
+        app_id,
+        temp_dir,
+        local_app_data,
+        is_upgrading,
     }
 }
 
@@ -113,6 +123,8 @@ fn remove_msi_arp_registry_keys(fn_name: &str, app_id: &str) {
     const UNINSTALL_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
     let subkey = format!("MSI:{}", app_id);
     for root in [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE] {
+        // KEY_READ on the parent is enough: RegDeleteTreeW opens the named subkey itself with
+        // the rights it needs (covered by the unit test below, incl. foreign values/subkeys)
         if let Ok(uninstall) = RegKey::predef(root).open_subkey(UNINSTALL_KEY) {
             if let Err(e) = uninstall.delete_subkey_all(&subkey) {
                 show_debug_message(fn_name, format!("Did not remove uninstall registry key {:?}: {}", subkey, e));
@@ -361,4 +373,48 @@ fn show_debug_message(fn_name: &str, message: String) {
 #[cfg(not(debug_assertions))]
 fn show_debug_message(_fn_name: &str, _message: String) {
     // no-op
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    #[test]
+    fn removes_arp_key_with_values_and_subkeys() {
+        // MSI only removes the registry values it authored; the helper must be able to delete a
+        // key that still holds foreign values and nested subkeys
+        let app_id = "VelopackWixArpTest";
+        let path = format!("Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MSI:{}", app_id);
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        {
+            let (key, _) = hkcu.create_subkey(&path).unwrap();
+            key.set_value("DisplayName", &"leftover").unwrap();
+            let (nested, _) = key.create_subkey("Nested").unwrap();
+            nested.set_value("Extra", &1u32).unwrap();
+        }
+
+        remove_msi_arp_registry_keys("test", app_id);
+
+        assert!(hkcu.open_subkey(&path).is_err(), "ARP key should have been deleted");
+    }
+
+    #[test]
+    fn parse_cleanup_data_rejects_unsafe_app_id() {
+        let d = parse_cleanup_data("C:\\install\"..\\evil\"C:\\temp\"C:\\lad");
+        assert!(d.app_id.is_empty());
+
+        let d = parse_cleanup_data("C:\\install\"..\"C:\\temp\"C:\\lad\"{PRODUCT-CODE}");
+        assert!(d.app_id.is_empty());
+        assert!(d.is_upgrading);
+
+        let d = parse_cleanup_data("C:\\install\"MyApp\"C:\\temp\"C:\\lad\"");
+        assert_eq!(d.app_id, "MyApp");
+        assert!(!d.is_upgrading);
+
+        let d = parse_cleanup_data("C:\\install\"MyApp\"C:\\temp\"C:\\lad");
+        assert_eq!(d.app_id, "MyApp");
+        assert!(!d.is_upgrading);
+    }
 }

--- a/test/Velopack.Packaging.Tests/MsiTests.cs
+++ b/test/Velopack.Packaging.Tests/MsiTests.cs
@@ -454,6 +454,76 @@ public class MsiTests
     }
 
     [Fact]
+    public async Task TestPackGeneratesMsiWithUpgradeAwareCleanup()
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+
+        using var logger = _output.BuildLoggerFor<MsiTests>();
+
+        using var _1 = TempUtil.GetTempDirectory(out var tmpOutput);
+        using var _2 = TempUtil.GetTempDirectory(out var tmpReleaseDir);
+
+        var exe = "testapp.exe";
+        var id = "Test.Squirrel-App";
+
+        PathHelper.CopyRustAssetTo(exe, tmpOutput);
+        PathHelper.CopyRustAssetTo(Path.ChangeExtension(exe, ".pdb"), tmpOutput);
+
+        var options = new WindowsPackOptions {
+            EntryExecutableName = exe,
+            ReleaseDir = new DirectoryInfo(tmpReleaseDir),
+            PackId = id,
+            PackVersion = "1.2.3",
+            TargetRuntime = RID.Parse("win-x64"),
+            PackDirectory = tmpOutput,
+            BuildMsi = true,
+        };
+
+        var runner = WindowsTestHelper.GetPackRunner(logger);
+        await runner.Run(options);
+
+        string msiPath = Path.Combine(tmpReleaseDir, $"{id}-win.msi");
+        Assert.True(File.Exists(msiPath));
+
+        using Database db = new Database(msiPath);
+
+        // the app uninstall hook and the per-user cleanup must only run on a real uninstall, not
+        // when the old product is removed as part of a major upgrade (#1004)
+        const string uninstallOnly = "(REMOVE=\"ALL\") AND NOT UPGRADINGPRODUCTCODE";
+        foreach (var action in new[] { "SetUninstallHookData", "UninstallHookDeferred", "SetUserRustCleanupData", "UserRustCleanup" }) {
+            var condition = db.ExecuteScalar($"SELECT `Condition` FROM `InstallExecuteSequence` WHERE `Action` = '{action}'") as string;
+            Assert.Equal(uninstallOnly, condition);
+        }
+
+        // RustCleanup runs on uninstall AND upgrade; the marshaled UPGRADINGPRODUCTCODE tells it
+        // whether to remove everything or only purge the `current` payload dir
+        var cleanupCondition = db.ExecuteScalar("SELECT `Condition` FROM `InstallExecuteSequence` WHERE `Action` = 'RustCleanup'") as string;
+        Assert.Equal("(REMOVE=\"ALL\")", cleanupCondition);
+        var cleanupData = db.ExecuteScalar("SELECT `Target` FROM `CustomAction` WHERE `Action` = 'SetRustCleanupData'") as string;
+        Assert.Equal("[INSTALLFOLDER]\"[RustAppId]\"[TempFolder]\"[LocalAppDataFolder]\"[UPGRADINGPRODUCTCODE]", cleanupData);
+        var userCleanupData = db.ExecuteScalar("SELECT `Target` FROM `CustomAction` WHERE `Action` = 'SetUserRustCleanupData'") as string;
+        Assert.Equal("[INSTALLFOLDER]\"[RustAppId]\"[TempFolder]\"[LocalAppDataFolder]", userCleanupData);
+
+        // RustCleanup must run non-impersonated (elevated for per-machine installs) so it can
+        // remove a Program Files install dir; UserRustCleanup must run impersonated so it resolves
+        // the installing user's profile (shortcuts, %LocalAppData% fallback dir) instead of the
+        // SYSTEM profile (#989)
+        const int msidbCustomActionTypeNoImpersonate = 2048;
+        var cleanupType = Convert.ToInt32(db.ExecuteScalar("SELECT `Type` FROM `CustomAction` WHERE `Action` = 'RustCleanup'"));
+        Assert.True((cleanupType & msidbCustomActionTypeNoImpersonate) != 0, "RustCleanup should be non-impersonated");
+        var userCleanupType = Convert.ToInt32(db.ExecuteScalar("SELECT `Type` FROM `CustomAction` WHERE `Action` = 'UserRustCleanup'"));
+        Assert.True((userCleanupType & msidbCustomActionTypeNoImpersonate) == 0, "UserRustCleanup should be impersonated");
+
+        // ordering: hook runs while the app files still exist; cleanup runs after MSI removed its
+        // own files and before RemoveFolders
+        int Seq(string action) => Convert.ToInt32(db.ExecuteScalar($"SELECT `Sequence` FROM `InstallExecuteSequence` WHERE `Action` = '{action}'"));
+        Assert.True(Seq("UninstallHookDeferred") < Seq("RemoveFiles"), "uninstall hook should run before RemoveFiles");
+        Assert.True(Seq("RemoveFiles") < Seq("RustCleanup"), "RustCleanup should run after RemoveFiles");
+        Assert.True(Seq("RustCleanup") < Seq("UserRustCleanup"), "UserRustCleanup should run after RustCleanup");
+        Assert.True(Seq("UserRustCleanup") < Seq("RemoveFolders"), "UserRustCleanup should run before RemoveFolders");
+    }
+
+    [Fact]
     public async Task TestPackGeneratesMsiWithBracketsInTitle()
     {
         Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
@@ -650,6 +720,113 @@ public class MsiTests
     }
 
     [Fact]
+    public async Task TestMsiUpgradeKeepsUserDataAndUninstallCleansEverything()
+    {
+        Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
+        using var logger = _output.BuildLoggerFor<MsiTests>();
+        using var _1 = TempUtil.GetTempDirectory(out var releaseDir);
+
+        string id = "MsiUpgradeTest";
+        var installDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), id);
+        var msiPath = Path.Combine(releaseDir, $"{id}-win.msi");
+        var appPath = Path.Combine(installDir, "current", "TestApp.exe");
+        var hookTempDir = Path.Combine(Path.GetTempPath(), $"velopack_hooks_{id}");
+        var hookFile = Path.Combine(hookTempDir, "args.txt");
+        var velopackTempDir = Path.Combine(Path.GetTempPath(), $"velopack_{id}");
+        var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+        var msiShortcut = Path.Combine(desktop, $"{id}.lnk");
+        var userShortcut = Path.Combine(desktop, $"{id} User Copy.lnk");
+
+        try {
+            // clean up any leftover hook files from previous runs
+            if (Directory.Exists(hookTempDir))
+                IoUtil.DeleteFileOrDirectoryHard(hookTempDir);
+
+            // pack + install v1
+            await PackTestAppWithMsi(id, "1.0.0", "version 1 test", releaseDir, logger, InstallLocation.PerUser);
+            logger.Info("TEST: Installing v1 MSI...");
+            RunMsiExec($"/i \"{msiPath}\" /qn", logger);
+            Assert.True(File.Exists(appPath), $"TestApp.exe not found at {appPath}");
+            Assert.True(File.Exists(msiShortcut), $"Desktop shortcut not found at {msiShortcut}");
+
+            // simulate user state: a data dir outside `current` (must survive MSI upgrades) and a
+            // stray file inside `current` (must be purged so the upgrade lays down a clean payload)
+            var userDataFile = Path.Combine(installDir, "user-data", "settings.json");
+            Directory.CreateDirectory(Path.Combine(installDir, "user-data"));
+            File.WriteAllText(userDataFile, "{}");
+            var strayPayloadFile = Path.Combine(installDir, "current", "stray-old-file.txt");
+            File.WriteAllText(strayPayloadFile, "left behind by an in-app update");
+
+            // upgrade by running the v2 MSI directly (not via in-app update)
+            await PackTestAppWithMsi(id, "2.0.0", "version 2 test", releaseDir, logger, InstallLocation.PerUser);
+            WaitUntilInstallDirUnlocked(installDir);
+            logger.Info("TEST: Upgrading via v2 MSI...");
+            RunMsiExec($"/i \"{msiPath}\" /qn", logger);
+
+            var chk2version = WindowsTestHelper.RunCoveredDotnet(appPath, ["version"], installDir, logger);
+            Assert.EndsWith(Environment.NewLine + "2.0.0", chk2version);
+            Assert.True(File.Exists(userDataFile), "User data outside `current` should survive an MSI upgrade");
+            Assert.False(File.Exists(strayPayloadFile), "Files inside `current` should be purged by an MSI upgrade");
+            var (found, displayVersion) = FindUninstallEntry(Registry.CurrentUser, id);
+            Assert.True(found, "Uninstall entry should exist in HKCU after upgrade");
+            Assert.Equal("2.0.0", displayVersion);
+
+            // the app uninstall hook must not fire when the old product is removed by the upgrade
+            var hookContent = File.Exists(hookFile) ? File.ReadAllText(hookFile) : "";
+            Assert.DoesNotContain("OnBeforeUninstallFastCallback", hookContent);
+            logger.Info("TEST: v2 upgrade verified, user data intact, no uninstall hook");
+
+            // simulate a user-created shortcut pointing into the install dir; uninstall cleanup
+            // should sweep it even though the MSI did not create it
+            File.Copy(msiShortcut, userShortcut, true);
+
+            // uninstall
+            WaitUntilInstallDirUnlocked(installDir);
+            logger.Info("TEST: Uninstalling v2 MSI...");
+            RunMsiExec($"/x \"{msiPath}\" /qn", logger);
+
+            Assert.True(File.Exists(hookFile), $"Uninstall hook file not found at {hookFile}");
+            Assert.Contains("OnBeforeUninstallFastCallback: --veloapp-uninstall", File.ReadAllText(hookFile));
+            Assert.False(Directory.Exists(installDir),
+                $"Install directory (incl. user data) should have been removed: {installDir}");
+            var (found2, _) = FindUninstallEntry(Registry.CurrentUser, id);
+            Assert.False(found2, "Uninstall entry should be removed from HKCU after uninstall");
+            Assert.False(File.Exists(msiShortcut), "MSI desktop shortcut should be removed on uninstall");
+            Assert.False(File.Exists(userShortcut), "User-created shortcut into the install dir should be removed on uninstall");
+            Assert.False(Directory.Exists(velopackTempDir), $"Velopack temp dir should have been removed: {velopackTempDir}");
+            logger.Info("TEST: uninstall cleanup verified");
+        } finally {
+            // cleanup: uninstall MSI (best effort, may already be uninstalled)
+            try {
+                if (File.Exists(msiPath)) {
+                    RunMsiExec($"/x \"{msiPath}\" /qn", logger, exitCode: null);
+                }
+            } catch {
+                // best effort cleanup
+            }
+
+            foreach (var dir in new[] { installDir, hookTempDir }) {
+                try {
+                    if (Directory.Exists(dir)) {
+                        IoUtil.Retry(() => IoUtil.DeleteFileOrDirectoryHard(dir), 10, 1000);
+                    }
+                } catch {
+                    // best effort cleanup
+                }
+            }
+
+            foreach (var lnk in new[] { msiShortcut, userShortcut }) {
+                try {
+                    File.Delete(lnk);
+                } catch {
+                    // best effort cleanup
+                }
+            }
+        }
+    }
+
+    [Fact]
     public async Task TestMsiInstallToCustomDirViaVelopackInstallDir()
     {
         Assert.SkipUnless(VelopackRuntimeInfo.IsWindows, "Windows only");
@@ -723,12 +900,16 @@ public class MsiTests
         var fallbackDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), id);
         var msiPath = Path.Combine(releaseDir, $"{id}-win.msi");
+        // save v1 MSI path separately — packing v2 overwrites msiPath, and uninstalling requires
+        // an MSI whose ProductCode matches the installed product (in-app updates don't change it).
+        var v1MsiPath = Path.Combine(releaseDir, $"{id}-v1.msi");
         var appPath = Path.Combine(installDir, "current", "TestApp.exe");
 
         try {
             // pack v1
             await PackTestAppWithMsi(id, "1.0.0", "version 1 test", releaseDir, logger, InstallLocation.Either);
             Assert.True(File.Exists(msiPath), $"MSI not found at {msiPath}");
+            File.Copy(msiPath, v1MsiPath, true);
 
             // install via msiexec with ALLUSERS=1 (per-machine, requires admin). no INSTALLFOLDER
             // is passed on purpose: silent per-machine installs must default to Program Files (#945)
@@ -796,10 +977,25 @@ public class MsiTests
             Assert.True(hklmFound2, "Uninstall entry should still exist in HKLM after update");
             Assert.Equal("2.0.0", hklmVersion2);
             logger.Info("TEST: registry entry verified in HKLM with version 2.0.0");
+
+            // uninstall: must remove the Program Files install dir, the HKLM ARP entry, AND the
+            // per-user fallback dir in %LocalAppData% which holds packages + Update.exe (#989)
+            WaitUntilInstallDirUnlocked(installDir);
+            logger.Info("TEST: Uninstalling MSI...");
+            RunMsiExec($"/x \"{v1MsiPath}\" /qn", logger);
+
+            Assert.False(Directory.Exists(installDir), $"Install directory should have been removed: {installDir}");
+            Assert.False(Directory.Exists(fallbackDir),
+                $"LocalAppData fallback directory should have been removed: {fallbackDir}");
+            var (hklmFound3, _) = FindUninstallEntry(Registry.LocalMachine, id);
+            Assert.False(hklmFound3, "Uninstall entry should be removed from HKLM after uninstall");
+            logger.Info("TEST: uninstall cleanup verified");
         } finally {
-            // cleanup: uninstall MSI
+            // cleanup: uninstall MSI (best effort, may already be uninstalled)
             try {
-                RunMsiExec($"/x \"{msiPath}\" /qn", logger, exitCode: null);
+                if (File.Exists(v1MsiPath)) {
+                    RunMsiExec($"/x \"{v1MsiPath}\" /qn", logger, exitCode: null);
+                }
             } catch {
                 // best effort cleanup
             }

--- a/test/Velopack.Packaging.Tests/MsiTests.cs
+++ b/test/Velopack.Packaging.Tests/MsiTests.cs
@@ -145,7 +145,7 @@ public class MsiTests
     }
 
     private static async Task PackTestAppWithMsi(string id, string version, string testString,
-        string releaseDir, ILogger logger, InstallLocation instLocation)
+        string releaseDir, ILogger logger, InstallLocation instLocation, string packTitle = null)
     {
         using var _ = TempUtil.GetTempDirectory(out var workDir);
 
@@ -158,6 +158,7 @@ public class MsiTests
                 ReleaseDir = new DirectoryInfo(releaseDir),
                 PackId = id,
                 PackVersion = version,
+                PackTitle = packTitle,
                 TargetRuntime = RID.Parse("win-x64"),
                 PackDirectory = publishDir,
                 BuildMsi = true,
@@ -474,6 +475,7 @@ public class MsiTests
             ReleaseDir = new DirectoryInfo(tmpReleaseDir),
             PackId = id,
             PackVersion = "1.2.3",
+            PackTitle = "Squirrel Test Title",
             TargetRuntime = RID.Parse("win-x64"),
             PackDirectory = tmpOutput,
             BuildMsi = true,
@@ -486,6 +488,11 @@ public class MsiTests
         Assert.True(File.Exists(msiPath));
 
         using Database db = new Database(msiPath);
+
+        // cleanup paths (LocalAppData fallback dir, temp dir, MSI:{id} ARP key) are derived from
+        // the pack ID, never from the display title
+        var rustAppId = db.ExecuteScalar("SELECT `Value` FROM `Property` WHERE `Property` = 'RustAppId'") as string;
+        Assert.Equal(id, rustAppId);
 
         // the app uninstall hook and the per-user cleanup must only run on a real uninstall, not
         // when the old product is removed as part of a major upgrade (#1004)
@@ -521,6 +528,16 @@ public class MsiTests
         Assert.True(Seq("RemoveFiles") < Seq("RustCleanup"), "RustCleanup should run after RemoveFiles");
         Assert.True(Seq("RustCleanup") < Seq("UserRustCleanup"), "UserRustCleanup should run after RustCleanup");
         Assert.True(Seq("UserRustCleanup") < Seq("RemoveFolders"), "UserRustCleanup should run before RemoveFolders");
+
+        // the upgrade-mode `current` purge relies on the old product being removed (and cleaned)
+        // before the new payload is laid down — pin WiX's implicit early RemoveExistingProducts
+        Assert.True(Seq("RemoveExistingProducts") < Seq("InstallFiles"),
+            "RemoveExistingProducts must be scheduled before InstallFiles");
+
+        // VELOPACK_INSTALLDIR only applies on first install; on maintenance/uninstall the
+        // INSTALLFOLDER handed to the elevated cleanup must come from the registered install state
+        var overrideCondition = db.ExecuteScalar("SELECT `Condition` FROM `InstallExecuteSequence` WHERE `Action` = 'SetINSTALLFOLDER'") as string;
+        Assert.Equal("VELOPACK_INSTALLDIR AND NOT Installed", overrideCondition);
     }
 
     [Fact]
@@ -727,16 +744,20 @@ public class MsiTests
         using var _1 = TempUtil.GetTempDirectory(out var releaseDir);
 
         string id = "MsiUpgradeTest";
-        var installDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), id);
+        // a title distinct from the ID: shortcuts/stub use the title, but cleanup paths
+        // (LocalAppData fallback, temp, ARP key) must be derived from the ID
+        string title = "Msi Upgrade Test App";
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var installDir = Path.Combine(localAppData, id);
+        var titleDir = Path.Combine(localAppData, title);
         var msiPath = Path.Combine(releaseDir, $"{id}-win.msi");
         var appPath = Path.Combine(installDir, "current", "TestApp.exe");
         var hookTempDir = Path.Combine(Path.GetTempPath(), $"velopack_hooks_{id}");
         var hookFile = Path.Combine(hookTempDir, "args.txt");
         var velopackTempDir = Path.Combine(Path.GetTempPath(), $"velopack_{id}");
         var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-        var msiShortcut = Path.Combine(desktop, $"{id}.lnk");
-        var userShortcut = Path.Combine(desktop, $"{id} User Copy.lnk");
+        var msiShortcut = Path.Combine(desktop, $"{title}.lnk");
+        var userShortcut = Path.Combine(desktop, $"{title} User Copy.lnk");
 
         try {
             // clean up any leftover hook files from previous runs
@@ -744,7 +765,7 @@ public class MsiTests
                 IoUtil.DeleteFileOrDirectoryHard(hookTempDir);
 
             // pack + install v1
-            await PackTestAppWithMsi(id, "1.0.0", "version 1 test", releaseDir, logger, InstallLocation.PerUser);
+            await PackTestAppWithMsi(id, "1.0.0", "version 1 test", releaseDir, logger, InstallLocation.PerUser, title);
             logger.Info("TEST: Installing v1 MSI...");
             RunMsiExec($"/i \"{msiPath}\" /qn", logger);
             Assert.True(File.Exists(appPath), $"TestApp.exe not found at {appPath}");
@@ -759,7 +780,7 @@ public class MsiTests
             File.WriteAllText(strayPayloadFile, "left behind by an in-app update");
 
             // upgrade by running the v2 MSI directly (not via in-app update)
-            await PackTestAppWithMsi(id, "2.0.0", "version 2 test", releaseDir, logger, InstallLocation.PerUser);
+            await PackTestAppWithMsi(id, "2.0.0", "version 2 test", releaseDir, logger, InstallLocation.PerUser, title);
             WaitUntilInstallDirUnlocked(installDir);
             logger.Info("TEST: Upgrading via v2 MSI...");
             RunMsiExec($"/i \"{msiPath}\" /qn", logger);
@@ -781,6 +802,18 @@ public class MsiTests
             // should sweep it even though the MSI did not create it
             File.Copy(msiShortcut, userShortcut, true);
 
+            // an unrelated dir named after the display title must NOT be deleted by cleanup
+            Directory.CreateDirectory(titleDir);
+            File.WriteAllText(Path.Combine(titleDir, "unrelated.txt"), "not velopack's data");
+
+            // a foreign value under the ARP key: MSI only removes the values it authored, so the
+            // cleanup sweep must delete the remainder of the key
+            using (var arpKey = Registry.CurrentUser.OpenSubKey(
+                       $@"Software\Microsoft\Windows\CurrentVersion\Uninstall\MSI:{id}", writable: true)) {
+                Assert.NotNull(arpKey);
+                arpKey.SetValue("ForeignValue", "written by someone else");
+            }
+
             // uninstall
             WaitUntilInstallDirUnlocked(installDir);
             logger.Info("TEST: Uninstalling v2 MSI...");
@@ -795,6 +828,8 @@ public class MsiTests
             Assert.False(File.Exists(msiShortcut), "MSI desktop shortcut should be removed on uninstall");
             Assert.False(File.Exists(userShortcut), "User-created shortcut into the install dir should be removed on uninstall");
             Assert.False(Directory.Exists(velopackTempDir), $"Velopack temp dir should have been removed: {velopackTempDir}");
+            Assert.True(File.Exists(Path.Combine(titleDir, "unrelated.txt")),
+                "Unrelated dir named after the display title must not be touched by cleanup");
             logger.Info("TEST: uninstall cleanup verified");
         } finally {
             // cleanup: uninstall MSI (best effort, may already be uninstalled)
@@ -806,7 +841,7 @@ public class MsiTests
                 // best effort cleanup
             }
 
-            foreach (var dir in new[] { installDir, hookTempDir }) {
+            foreach (var dir in new[] { installDir, hookTempDir, titleDir }) {
                 try {
                     if (Directory.Exists(dir)) {
                         IoUtil.Retry(() => IoUtil.DeleteFileOrDirectoryHard(dir), 10, 1000);


### PR DESCRIPTION
Fixes #989, fixes #1004 (related: #1003).

Previously, a major MSI upgrade ran the old product's full cleanup action (`REMOVE="ALL"` is also set during `RemoveExistingProducts`), wiping the entire install dir including user files. And on uninstall, the cleanup action ran as SYSTEM on per-machine installs, so `%LOCALAPPDATA%` resolved to the SYSTEM profile and the per-user fallback dir (packages + Update.exe) was left behind.

Changes:
- **MSI upgrades** no longer wipe user files or run the app uninstall hook. The cleanup detects `UPGRADINGPRODUCTCODE` and only purges the `current` payload dir (so files from prior in-app updates can't mix with the new payload); everything outside `current` survives, matching the documented update contract.
- **Uninstall** now mirrors the Update.exe uninstall logic: force-stops processes running from the install dir, removes the install dir entirely, sweeps all shortcuts pointing into it (including user-created ones), and removes leftover `MSI:{AppId}` ARP registry keys.
- A new **impersonated** custom action (`UserCleanupDeferred`) cleans the per-user state the SYSTEM-context action cannot reach on per-machine installs: shortcuts, the `%LocalAppData%\{AppId}` fallback dir, the velopack temp dir, and the HKCU ARP key. `LocalAppDataFolder`/`TempFolder` are now marshaled through CustomActionData instead of read from environment variables at runtime.

Note: installs already in the field carry the old MSI/DLL, so their first upgrade to a new MSI will still run the old (wiping) cleanup once; behavior is correct from then on.

Tests: new E2E test covering install → MSI upgrade (user data preserved, `current` purged, no uninstall hook) → uninstall (dir, ARP key, shortcuts, temp all removed); a static authoring test over the MSI tables (conditions, impersonation flags, sequencing); and the explicit elevated per-machine test now asserts the `%LocalAppData%` fallback dir is removed on uninstall (#989).