### PR TITLE
Fix --signTemplate double-escaping every batch after the first on Linux/macOS

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
+++ b/src/vpk/Velopack.Packaging.Windows/CodeSign.cs
@@ -66,7 +66,7 @@ public class CodeSign
                 Log.Info("Preparing to codesign using a single file signing template, ignoring --signParallel option.");
                 parallelism = 1;
             } else if (signArguments.Contains("{{file...}}")) {
-                Log.Info($"Preparing to codesign using a single file signing template, with a parallelism of {parallelism}.");
+                Log.Info($"Preparing to codesign using a multiple file signing template, with a parallelism of {parallelism}.");
                 signArguments = signArguments.Replace("{{file...}}", "{{file}}");
             } else {
                 throw new UserInfoException(
@@ -82,19 +82,24 @@ public class CodeSign
             Log.Info($"{pendingSign.Count} file(s) will be signed, {diff} will be skipped.");
         }
 
+        // Escape once, before the loop. Escaping inside it re-escapes an already-escaped
+        // string, so every batch after the first was corrupted: a template containing
+        // \ $ ` " or ' would fail from the second batch onwards. That is the common case
+        // rather than an edge one, because a {{file}} template pins parallelism to 1 and
+        // so gives every file its own batch.
+        if (!VelopackRuntimeInfo.IsWindows) {
+            signArguments = EscapeForBash(signArguments);
+        }
+
         do {
             List<string> filesToSign = [];
             for (int i = Math.Max(1, Math.Min(pendingSign.Count, parallelism)); i > 0; i--) {
                 filesToSign.Add(pendingSign.Dequeue());
             }
 
-            string filesToSignStr;
-            if (VelopackRuntimeInfo.IsWindows) {
-                filesToSignStr = QuoteFileArgsWindows(filesToSign);
-            } else {
-                filesToSignStr = QuoteFileArgsBash(filesToSign);
-                signArguments = EscapeForBash(signArguments);
-            }
+            string filesToSignStr = VelopackRuntimeInfo.IsWindows
+                ? QuoteFileArgsWindows(filesToSign)
+                : QuoteFileArgsBash(filesToSign);
 
             string command;
             if (signAsTemplate) {

--- a/test/Velopack.Packaging.Tests/CodeSignTests.cs
+++ b/test/Velopack.Packaging.Tests/CodeSignTests.cs
@@ -700,6 +700,100 @@ public class CodeSignTests
     }
 
     [Fact]
+    public void Sign_Template_SingleFileTemplate_ManyFiles_TemplateNotDoubleEscaped()
+    {
+        // A {{file}} template pins parallelism to 1, so each file is its own batch.
+        // If the template is escaped inside the batch loop it gets re-escaped every
+        // time, and everything after the first file fails.
+        Assert.SkipWhen(VelopackRuntimeInfo.IsWindows, "bash-only test");
+
+        using var logger = _output.BuildLoggerFor<CodeSignTests>(LogLevel.Debug);
+        var console = new BasicConsole(logger, new VelopackDefaults(true));
+        var signer = new CodeSign(logger, console);
+
+        using var _1 = TempUtil.GetTempDirectory(out var dir);
+
+        var files = new[] {
+            Path.Combine(dir, "one.exe"),
+            Path.Combine(dir, "two.exe"),
+            Path.Combine(dir, "three.exe"),
+        };
+        foreach (var f in files) File.WriteAllText(f, "dummy");
+
+        // Contains the characters EscapeForBash exists to protect: quotes and '$'.
+        signer.Sign(files, "echo \"marker_$V\" {{file}}", 1, _ => { }, true);
+
+        var signOutput = GetSignToolOutput(logger);
+        foreach (var f in files) {
+            Assert.Contains(Path.GetFileName(f), signOutput);
+        }
+
+        // One line per batch, each with the literal marker: proof no batch was corrupted.
+        var markers = signOutput.Split("marker_$V").Length - 1;
+        Assert.Equal(files.Length, markers);
+    }
+
+    [Fact]
+    public void Sign_Template_MultiFileTemplate_MoreFilesThanParallelism_NotDoubleEscaped()
+    {
+        // Same defect via the {{file...}} path, where batching happens once the file
+        // count exceeds --signParallel.
+        Assert.SkipWhen(VelopackRuntimeInfo.IsWindows, "bash-only test");
+
+        using var logger = _output.BuildLoggerFor<CodeSignTests>(LogLevel.Debug);
+        var console = new BasicConsole(logger, new VelopackDefaults(true));
+        var signer = new CodeSign(logger, console);
+
+        using var _1 = TempUtil.GetTempDirectory(out var dir);
+
+        var files = new[] {
+            Path.Combine(dir, "a.exe"),
+            Path.Combine(dir, "b.exe"),
+            Path.Combine(dir, "c.exe"),
+            Path.Combine(dir, "d.exe"),
+            Path.Combine(dir, "e.exe"),
+        };
+        foreach (var f in files) File.WriteAllText(f, "dummy");
+
+        // 5 files at a parallelism of 2 gives batches of 2, 2 and 1.
+        signer.Sign(files, "echo \"marker_$V\" {{file...}}", 2, _ => { }, true);
+
+        var signOutput = GetSignToolOutput(logger);
+        foreach (var f in files) {
+            Assert.Contains(Path.GetFileName(f), signOutput);
+        }
+
+        var markers = signOutput.Split("marker_$V").Length - 1;
+        Assert.Equal(3, markers);
+    }
+
+    [Fact]
+    public void Sign_Template_MultipleBatches_CopyToQuotedDestination_Succeeds()
+    {
+        // The end-to-end shape a real signing template has: a quoted argument that
+        // must survive every batch, not just the first.
+        Assert.SkipWhen(VelopackRuntimeInfo.IsWindows, "bash-only test");
+
+        using var logger = _output.BuildLoggerFor<CodeSignTests>(LogLevel.Debug);
+        var console = new BasicConsole(logger, new VelopackDefaults(true));
+        var signer = new CodeSign(logger, console);
+
+        using var _1 = TempUtil.GetTempDirectory(out var dir);
+
+        var file1 = Path.Combine(dir, "first.exe");
+        var file2 = Path.Combine(dir, "second.exe");
+        File.WriteAllText(file1, "data-1");
+        File.WriteAllText(file2, "data-2");
+
+        var destFile = Path.Combine(dir, "dest_$V.bin");
+        signer.Sign([file1, file2], $"cp {{{{file}}}} \"{destFile}\"", 1, _ => { }, true);
+
+        // Both batches ran, so the destination holds the second file's contents.
+        Assert.True(File.Exists(destFile), "Destination must exist with '$' taken literally.");
+        Assert.Equal("data-2", File.ReadAllText(destFile));
+    }
+
+    [Fact]
     public void Sign_Template_WindowsCmdMetacharactersInDestination_Work()
     {
         // Windows: cmd-meaningful chars (parens, &, %) inside the quoted dest


### PR DESCRIPTION
`--signTemplate` corrupts its own command on Linux/macOS for every file after the first.

`EscapeForBash(signArguments)` is called **inside** the batching loop, so each iteration escapes an already-escaped string:

```csharp
do {
    ...
    } else {
        filesToSignStr = QuoteFileArgsBash(filesToSign);
        signArguments = EscapeForBash(signArguments);   // <-- re-escapes each batch
    }
```

Batch 1 is correct; batch 2 has been escaped twice, batch 3 three times.

### Why this isn't an edge case

A `{{file}}` template pins `parallelism` to 1, so **every file is its own batch**. Any template containing `\`, `$`, `` ` ``, `"` or `'` — which is most real signing commands, since credentials and URLs get quoted — fails on the second file onwards.

A `{{file...}}` template hits the same thing once the file count exceeds `--signParallel` (default 10).

### Reproduction

Two files, `parallelism: 1`, template `cp {{file}} "/tmp/out_$V.bin"`, driven through `CodeSign.Sign` on Ubuntu:

```
Sign() THREW: UserInfoException: Signing command failed.
Output was:
cp: cannot create regular file '"/tmp/vrepro-912b4c40/out_\$V.bin"': No such file or directory
```

The destination has picked up literal `"` and `\$`. The first file had already been copied correctly.

### The fix

Escape once, before the loop. The `filesToSignStr` branch collapses to a ternary since only the quoting differs per platform now.

### Tests

Three regression tests added to `CodeSignTests`, covering the `{{file}}` multi-batch path, the `{{file...}}` path with more files than `--signParallel`, and an end-to-end copy to a quoted destination across two batches.

All three fail on `develop` and pass with the fix:

| | `total` | `failed` | `succeeded` | `skipped` |
|---|---|---|---|---|
| without fix | 34 | **3** | 25 | 6 |
| with fix | 34 | **0** | 28 | 6 |

Full `Velopack.Packaging.Tests` run: 86 total, 61 passed, 24 skipped, 1 failed — `ResourceEditTests.CommitResourcesInCorrectOrder`, which fails identically on an unmodified checkout of `develop` and is unrelated to this change.

Also corrected one log message: the `{{file...}}` branch announced itself as "a single file signing template".

<sub>Found while checking whether Velopack could sign Windows packages from Linux — it can, and does, which is how the multi-batch path got exercised. Disclosure: the signing tool I was driving it with is my own, but nothing here references or depends on it.</sub>
