### PR TITLE
Sign with Azure Trusted Signing without signtool.exe (draft)

### DIFF
--- a/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
+++ b/src/vpk/Velopack.Packaging.Windows/Commands/WindowsPackCommandRunner.cs
@@ -326,6 +326,13 @@ public class WindowsPackCommandRunner : PackageBuilder<WindowsPackOptions, Windo
             helper.Sign(filePaths, signTemplate, signParallel, progress, true);
         }
 
+        // Trusted Signing needs no signtool.exe, so it is the one signing method that can
+        // run anywhere. Windows keeps using the Dlib so its behaviour is unchanged.
+        if (!String.IsNullOrEmpty(trustedSignMetadataPath) && !VelopackRuntimeInfo.IsWindows) {
+            new NativeCodeSign(Log).SignWithTrustedSigning(filePaths, trustedSignMetadataPath, progress);
+            return;
+        }
+
         // signtool.exe does not work if we're not on windows.
         if (!VelopackRuntimeInfo.IsWindows) return;
 

--- a/src/vpk/Velopack.Packaging.Windows/NativeCodeSign.cs
+++ b/src/vpk/Velopack.Packaging.Windows/NativeCodeSign.cs
@@ -1,0 +1,126 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SignUniversal.Authenticode;
+using SignUniversal.Msi;
+using SignUniversal.Signing;
+using SignUniversal.Signing.Azure;
+using Velopack.Core;
+using Velopack.Util;
+
+namespace Velopack.Packaging.Windows;
+
+/// <summary>
+/// Signs Windows binaries with Azure Trusted Signing without signtool.exe, so it works
+/// on Linux and macOS as well as Windows.
+/// </summary>
+/// <remarks>
+/// The signtool path needs the Trusted Signing Dlib, which is a native Windows binary.
+/// This uses the managed client instead: the digest goes to the service over HTTPS and a
+/// signature comes back, so the private key is never present locally on any platform.
+/// The metadata file is the same one <c>--azureTrustedSignFile</c> already takes.
+/// </remarks>
+public class NativeCodeSign
+{
+    private static readonly Uri DefaultTimestampUrl = new("http://timestamp.digicert.com");
+
+    public ILogger Log { get; }
+
+    public NativeCodeSign(ILogger logger)
+    {
+        Log = logger;
+    }
+
+    /// <summary>Signs each file with the Trusted Signing account named in the metadata file.</summary>
+    public void SignWithTrustedSigning(string[] filePaths, string metadataFilePath, Action<int> progress)
+    {
+        var metadata = TrustedSigningMetadata.Read(metadataFilePath);
+
+        Log.Info($"Code signing with Azure Trusted Signing (account '{metadata.AccountName}', profile '{metadata.CertificateProfileName}').");
+
+        // One session for the whole batch: each construction fetches the signing
+        // certificate, and the service mints a short-lived one per session.
+        using var signer = new TrustedSigningRemoteSigner(
+            metadata.Endpoint,
+            metadata.AccountName,
+            metadata.CertificateProfileName);
+
+        var toSign = filePaths.Where(f => !String.IsNullOrWhiteSpace(f)).ToArray();
+
+        for (int i = 0; i < toSign.Length; i++) {
+            SignOneFile(toSign[i], signer);
+            Log.Info($"Code-signed {i + 1}/{toSign.Length} files");
+            progress((int) ((double) (i + 1) / toSign.Length * 100));
+        }
+    }
+
+    private void SignOneFile(string filePath, IRemoteSigner signer)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+
+        if (!File.Exists(fullPath)) {
+            Log.Warn($"Cannot sign '{fullPath}', file does not exist.");
+            return;
+        }
+
+        // Trusted Signing certificates live about three days, so an untimestamped
+        // signature stops verifying almost immediately. Timestamping is not optional here.
+        if (Path.GetExtension(fullPath).Equals(".msi", StringComparison.OrdinalIgnoreCase)) {
+            MsiSigner.SignFile(fullPath, signer, HashAlgorithmName.SHA256, DefaultTimestampUrl);
+        } else {
+            PeSigner.SignFile(fullPath, signer, HashAlgorithmName.SHA256, DefaultTimestampUrl);
+        }
+    }
+
+    /// <summary>The subset of the signtool Dlib metadata file that identifies the account.</summary>
+    internal sealed record TrustedSigningMetadata(Uri Endpoint, string AccountName, string CertificateProfileName)
+    {
+        public static TrustedSigningMetadata Read(string path)
+        {
+            JsonElement root;
+            try {
+                using var stream = File.OpenRead(path);
+                using var document = JsonDocument.Parse(stream);
+                root = document.RootElement.Clone();
+            } catch (JsonException ex) {
+                throw new UserInfoException($"Trusted Signing metadata file '{path}' is not valid JSON: {ex.Message}");
+            }
+
+            var endpoint = GetString(root, "Endpoint");
+            var account = GetString(root, "CodeSigningAccountName");
+            var profile = GetString(root, "CertificateProfileName");
+
+            var missing = new[] {
+                endpoint == null ? "Endpoint" : null,
+                account == null ? "CodeSigningAccountName" : null,
+                profile == null ? "CertificateProfileName" : null,
+            }.Where(x => x != null).ToArray();
+
+            if (missing.Length > 0) {
+                throw new UserInfoException(
+                    $"Trusted Signing metadata file '{path}' is missing required field(s): {String.Join(", ", missing)}.");
+            }
+
+            if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri)) {
+                throw new UserInfoException(
+                    $"Trusted Signing metadata file '{path}' has an Endpoint that is not an absolute URL: '{endpoint}'.");
+            }
+
+            return new TrustedSigningMetadata(endpointUri, account, profile);
+        }
+
+        // The Dlib reads these case-insensitively, so metadata files in the wild vary.
+        private static string GetString(JsonElement root, string name)
+        {
+            foreach (var property in root.EnumerateObject()) {
+                if (String.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase)
+                    && property.Value.ValueKind == JsonValueKind.String) {
+                    var value = property.Value.GetString();
+                    return String.IsNullOrWhiteSpace(value) ? null : value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/vpk/Velopack.Packaging.Windows/Velopack.Packaging.Windows.csproj
+++ b/src/vpk/Velopack.Packaging.Windows/Velopack.Packaging.Windows.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="AsmResolver.PE.Win32Resources" Version="6.0.0" />
     <PackageReference Include="Microsoft.Security.Extensions" Version="1.4.0" />
     <PackageReference Include="Handlebars.Net" Version="2.1.6" />
-    <PackageReference Include="SignUniversal" Version="1.0.32" />
-    <PackageReference Include="SignUniversal.Azure" Version="1.0.32" />
+    <PackageReference Include="SignUniversal" Version="1.0.34" />
+    <PackageReference Include="SignUniversal.Azure" Version="1.0.34" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/vpk/Velopack.Packaging.Windows/Velopack.Packaging.Windows.csproj
+++ b/src/vpk/Velopack.Packaging.Windows/Velopack.Packaging.Windows.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="AsmResolver.PE.Win32Resources" Version="6.0.0" />
     <PackageReference Include="Microsoft.Security.Extensions" Version="1.4.0" />
     <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+    <PackageReference Include="SignUniversal" Version="1.0.32" />
+    <PackageReference Include="SignUniversal.Azure" Version="1.0.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
+++ b/src/vpk/Velopack.Vpk/Commands/Packaging/WindowsPackCommand.cs
@@ -89,14 +89,16 @@ public class WindowsPackCommand : PackCommand
             .SetArgumentHelpName("LOC")
             .SetDefault("Desktop,StartMenuRoot");
 
+        // Trusted Signing goes over HTTPS rather than through signtool.exe, so unlike the
+        // options below it is not restricted to Windows.
+        AddOption<FileInfo>((v) => AzureTrustedSignFile = v.ToFullNameOrNull(), ["--azureTrustedSignFile"])
+            .SetDescription("Path to Azure Trusted Signing metadata.json.")
+            .SetArgumentHelpName("PATH");
+
         if (VelopackRuntimeInfo.IsWindows) {
             AddOption<string>((v) => SignParameters = v, ["--signParams", "-n"])
                 .SetDescription("Sign files via signtool.exe using these parameters.")
                 .SetArgumentHelpName("PARAMS");
-
-            AddOption<FileInfo>((v) => AzureTrustedSignFile = v.ToFullNameOrNull(), ["--azureTrustedSignFile"])
-                .SetDescription("Path to Azure Trusted Signing metadata.json.")
-                .SetArgumentHelpName("PATH");
 
             AddOption<bool>((v) => BuildMsi = v, ["--msi"])
                 .SetDescription("Compile a .msi machine-wide bootstrap package.");


### PR DESCRIPTION
Draft, in response to [your question on the docs PR](https://github.com/velopack/velopack.docs/pull/69#issuecomment-5103808984) about a native option for signing Windows PE/MSI on nix. Easier to judge the integration shape from working code than from a description, so here it is - happy to throw it away or rework it however you'd prefer.

## What it does

`--azureTrustedSignFile` currently goes through `signtool.exe` plus the Trusted Signing Dlib, both native Windows binaries. So the option is registered only on Windows, and a cross-compiled Windows package can't use it.

But Trusted Signing is just an HTTPS service - a digest goes out, a signature comes back. Swapping the Dlib for the managed client makes **the same `metadata.json` work on Linux and macOS**, with the key still never present locally.

Windows is untouched: it keeps using the Dlib. Only the non-Windows path is new, so this adds a capability rather than changing one.

## Verified end to end

Against a live Trusted Signing account on Ubuntu 24.04:

```
[INF] Code signing with Azure Trusted Signing (account '…', profile '…').
[INF] Code-signed 6/6 files
[INF] Setup bundle created 'MyApp-win-Setup.exe'.
[INF] Code-signed 1/1 files
```

And the output, checked independently:

```
releases/MyApp-win-Setup.exe
  format:    PE image
  signer:    CN=Zomp Inc., O=Zomp Inc., L=Toronto, S=Ontario, C=CA
  chain:     4 certificate(s) embedded
  signature: valid
  covers this file: yes
  timestamp: 2026-07-28 15:27:16Z
```

A real certificate, full chain, timestamped. `MyApp.exe` inside the portable zip verifies the same way.

## What it costs you

`Velopack.Packaging.Windows` gains two package references: `SignUniversal` (PE/MSI Authenticode; pulls `System.Security.Cryptography.Pkcs` and `OpenMcdf`) and `SignUniversal.Azure` (pulls the Azure SDK). The Azure SDK is the real weight here, and it's your call whether that belongs in vpk. If it doesn't, the same seam works with a certificate held any other way - `IRemoteSigner` is a single `SignHash` method - so a PFX-only path would cost only the first package.

Those are mine, which is how I know they fit. They were Apache-2.0 when I opened this; they are **MIT** as of 1.0.34, so referencing them carries no LICENSE/NOTICE obligation for vpk.

## Things I'd want your opinion on

- **Timestamping.** The Windows path uses `http://timestamp.acs.microsoft.com`. I defaulted the native path to DigiCert instead, because the Microsoft one returns a chain that doesn't resolve against a stock Linux trust store. Worth making configurable.
- **Windows could use this too**, which would drop the Dlib entirely and make behaviour identical everywhere. I deliberately didn't, to keep the change additive.
- **No tests yet** - signing needs live credentials, so I wanted your read on the approach before deciding how to fake that seam.
- Page hashes aren't implemented, so signatures don't carry them.

