### PR TITLE
Write EstimatedSize as a REG_DWORD so Windows shows the app size

### DIFF
--- a/src/bins/src/windows/registry.rs
+++ b/src/bins/src/windows/registry.rs
@@ -18,7 +18,10 @@ pub fn write_uninstall_entry(locator: &VelopackLocator) -> Result<()> {
     let updater_path = locator.get_update_path();
 
     let folder_size = fs_extra::dir::get_size(locator.get_current_bin_dir()).unwrap_or(0);
-    let folder_size_kb = folder_size / 1024;
+    // Windows reads EstimatedSize as a REG_DWORD, so a u64 (REG_QWORD) is ignored and
+    // no size is shown. Saturate rather than truncate: the value is in KB, so a u32
+    // covers ~4TB.
+    let folder_size_kb = u32::try_from(folder_size / 1024).unwrap_or(u32::MAX);
     let short_version = locator.get_manifest_version_short_string();
 
     let now = DateTime::now();


### PR DESCRIPTION
Fixes #1050

`fs_extra::dir::get_size` returns a `u64`, so `folder_size_kb` stayed a `u64` and `winreg` wrote `EstimatedSize` as a `REG_QWORD`. Windows documents that value as a `REG_DWORD` and reads it only as one, so it is ignored and Installed apps shows no size for the app. The two values written just below it are already explicitly `u32`, which is what this one needed too.

Saturating rather than casting, since the value is in KB and a `u32` already covers about 4 TB.

The change is inside `src/bins/src/windows`, which `lib.rs` gates behind `#[cfg(target_os = "windows")]`, so macOS and Linux builds are unaffected.

I do not have a Rust toolchain on the machine that hit this, so this is compile-checked by CI rather than locally. Happy to adjust if you would rather have it written a different way.
